### PR TITLE
feat: add agent streaming event types and parser (v0.2.11 Thrusts 1-2)

### DIFF
--- a/packages/server/src/agent/stream-parser.ts
+++ b/packages/server/src/agent/stream-parser.ts
@@ -1,0 +1,494 @@
+/**
+ * Stream Parser for Claude Code JSON output
+ *
+ * Parses line-by-line JSON output from Claude Code and converts
+ * to typed events for WebSocket broadcasting.
+ */
+
+import type { Interface as ReadlineInterface } from 'node:readline';
+import { createLogger } from '../utils/index.js';
+import type {
+  AgentToolCallEvent,
+  AgentToolResultEvent,
+  AgentOutputEvent,
+  ProgressUpdateEvent,
+  AgentToolName,
+} from '../server/websocket/types.js';
+
+const logger = createLogger('agent:stream-parser');
+
+/**
+ * Maximum length for content preview in tool results
+ */
+const CONTENT_PREVIEW_MAX_LENGTH = 500;
+
+/**
+ * Default interval for progress updates (in milliseconds)
+ */
+const DEFAULT_PROGRESS_INTERVAL_MS = 5000;
+
+/**
+ * Raw Claude Code JSON line types
+ */
+export interface ClaudeSystemMessage {
+  type: 'system';
+  subtype: string;
+  cwd?: string;
+  session_id?: string;
+}
+
+export interface ClaudeAssistantTextMessage {
+  type: 'assistant';
+  message: {
+    type: 'text';
+    text: string;
+  };
+}
+
+export interface ClaudeAssistantToolUseMessage {
+  type: 'assistant';
+  message: {
+    type: 'tool_use';
+    id: string;
+    name: string;
+    input: Record<string, unknown>;
+  };
+}
+
+export interface ClaudeToolResultMessage {
+  type: 'user';
+  message: {
+    type: 'tool_result';
+    tool_use_id: string;
+    content: string;
+    is_error?: boolean;
+  };
+}
+
+export type ClaudeMessage =
+  | ClaudeSystemMessage
+  | ClaudeAssistantTextMessage
+  | ClaudeAssistantToolUseMessage
+  | ClaudeToolResultMessage;
+
+/**
+ * Union of all parsed event types
+ */
+export type ParsedEvent =
+  | AgentToolCallEvent
+  | AgentToolResultEvent
+  | AgentOutputEvent
+  | ProgressUpdateEvent;
+
+/**
+ * Options for the StreamParser
+ */
+export interface ParserOptions {
+  /** Interval for progress updates in milliseconds (default: 5000) */
+  progressIntervalMs?: number;
+  /** Enable debug logging */
+  debug?: boolean;
+}
+
+/**
+ * Internal tracking for tool call timing
+ */
+interface ToolCallTiming {
+  toolUseId: string;
+  startTime: number;
+}
+
+/**
+ * StreamParser parses Claude Code JSON output into typed events
+ */
+export class StreamParser {
+  private readonly progressIntervalMs: number;
+  private readonly debug: boolean;
+
+  /** Tracks active tool calls for duration calculation */
+  private activeToolCalls: Map<string, ToolCallTiming> = new Map();
+
+  /** Total tool calls made */
+  private toolCallCount = 0;
+
+  /** Start time for elapsed calculation */
+  private startTime: number | null = null;
+
+  /** Last progress update time */
+  private lastProgressTime = 0;
+
+  constructor(options: ParserOptions = {}) {
+    this.progressIntervalMs = options.progressIntervalMs ?? DEFAULT_PROGRESS_INTERVAL_MS;
+    this.debug = options.debug ?? false;
+  }
+
+  /**
+   * Parses a single JSON line from Claude Code output
+   *
+   * @param line - The JSON line to parse
+   * @returns The parsed Claude message or null if invalid/unrecognized
+   */
+  parseLine(line: string): ClaudeMessage | null {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+
+      if (!this.isClaudeMessage(parsed)) {
+        if (this.debug) {
+          logger.debug({ line: trimmed.substring(0, 100) }, 'Unrecognized message structure');
+        }
+        return null;
+      }
+
+      return parsed;
+    } catch (error) {
+      logger.warn({ line: trimmed.substring(0, 100), error }, 'Failed to parse JSON line');
+      return null;
+    }
+  }
+
+  /**
+   * Parses a tool_use message into an AgentToolCallEvent
+   */
+  parseToolUse(
+    message: ClaudeAssistantToolUseMessage,
+    workOrderId: string,
+    runId: string
+  ): AgentToolCallEvent {
+    const toolData = message.message;
+    const toolName = this.normalizeToolName(toolData.name);
+
+    // Track the tool call for duration calculation
+    const now = Date.now();
+    this.activeToolCalls.set(toolData.id, {
+      toolUseId: toolData.id,
+      startTime: now,
+    });
+
+    this.toolCallCount++;
+
+    return this.createToolCallEvent(workOrderId, runId, {
+      toolUseId: toolData.id,
+      tool: toolName,
+      input: toolData.input,
+    });
+  }
+
+  /**
+   * Parses a tool_result message into an AgentToolResultEvent
+   */
+  parseToolResult(
+    message: ClaudeToolResultMessage,
+    workOrderId: string,
+    runId: string
+  ): AgentToolResultEvent {
+    const resultData = message.message;
+    const toolUseId = resultData.tool_use_id;
+    const content = resultData.content;
+    const isError = resultData.is_error ?? false;
+
+    // Calculate duration from tracked tool call
+    let durationMs = 0;
+    const timing = this.activeToolCalls.get(toolUseId);
+    if (timing) {
+      durationMs = Date.now() - timing.startTime;
+      this.activeToolCalls.delete(toolUseId);
+    }
+
+    return this.createToolResultEvent(workOrderId, runId, {
+      toolUseId,
+      success: !isError,
+      content,
+      durationMs,
+    });
+  }
+
+  /**
+   * Parses a text message into an AgentOutputEvent
+   */
+  parseText(
+    message: ClaudeAssistantTextMessage,
+    workOrderId: string,
+    runId: string
+  ): AgentOutputEvent | null {
+    const text = message.message.text;
+
+    // Filter out empty or purely whitespace text
+    if (!text.trim()) {
+      return null;
+    }
+
+    return this.createOutputEvent(workOrderId, runId, text);
+  }
+
+  /**
+   * Async generator that parses a readline stream and yields events
+   */
+  async *parseStream(
+    readline: ReadlineInterface,
+    workOrderId: string,
+    runId: string
+  ): AsyncGenerator<ParsedEvent> {
+    this.startTime = Date.now();
+    this.lastProgressTime = this.startTime;
+    this.toolCallCount = 0;
+    this.activeToolCalls.clear();
+
+    for await (const line of readline) {
+      const message = this.parseLine(line);
+      if (!message) {
+        continue;
+      }
+
+      const event = this.messageToEvent(message, workOrderId, runId);
+      if (event) {
+        yield event;
+      }
+
+      // Check if we should emit a progress update
+      const progressEvent = this.maybeEmitProgress(workOrderId, runId);
+      if (progressEvent) {
+        yield progressEvent;
+      }
+    }
+  }
+
+  /**
+   * Creates a ProgressUpdateEvent based on current state
+   */
+  createProgressEvent(
+    workOrderId: string,
+    runId: string,
+    phase: string
+  ): ProgressUpdateEvent {
+    const now = Date.now();
+    const elapsedMs = this.startTime ? now - this.startTime : 0;
+    const elapsedSeconds = Math.floor(elapsedMs / 1000);
+
+    // Simple heuristic for percentage (can be improved)
+    // Based on tool call count, estimate progress
+    const percentage = Math.min(95, this.toolCallCount * 5);
+
+    return {
+      type: 'progress_update',
+      workOrderId,
+      runId,
+      percentage,
+      currentPhase: phase,
+      toolCallCount: this.toolCallCount,
+      elapsedSeconds,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Factory method: Creates an AgentToolCallEvent
+   */
+  createToolCallEvent(
+    workOrderId: string,
+    runId: string,
+    toolData: { toolUseId: string; tool: AgentToolName; input: Record<string, unknown> }
+  ): AgentToolCallEvent {
+    return {
+      type: 'agent_tool_call',
+      workOrderId,
+      runId,
+      toolUseId: toolData.toolUseId,
+      tool: toolData.tool,
+      input: toolData.input,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Factory method: Creates an AgentToolResultEvent
+   */
+  createToolResultEvent(
+    workOrderId: string,
+    runId: string,
+    resultData: { toolUseId: string; success: boolean; content: string; durationMs: number }
+  ): AgentToolResultEvent {
+    const contentPreview = this.truncateContent(resultData.content);
+
+    return {
+      type: 'agent_tool_result',
+      workOrderId,
+      runId,
+      toolUseId: resultData.toolUseId,
+      success: resultData.success,
+      contentPreview,
+      contentLength: resultData.content.length,
+      durationMs: resultData.durationMs,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Factory method: Creates an AgentOutputEvent
+   */
+  createOutputEvent(
+    workOrderId: string,
+    runId: string,
+    text: string
+  ): AgentOutputEvent {
+    return {
+      type: 'agent_output',
+      workOrderId,
+      runId,
+      content: text,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Normalizes a tool name from Claude Code to our AgentToolName type
+   */
+  private normalizeToolName(name: string): AgentToolName {
+    const knownTools: AgentToolName[] = [
+      'Read',
+      'Write',
+      'Edit',
+      'Bash',
+      'Grep',
+      'Glob',
+      'WebFetch',
+      'WebSearch',
+    ];
+
+    // Case-insensitive match
+    const normalized = knownTools.find(
+      (tool) => tool.toLowerCase() === name.toLowerCase()
+    );
+
+    return normalized ?? 'Other';
+  }
+
+  /**
+   * Type guard for ClaudeMessage
+   */
+  private isClaudeMessage(value: unknown): value is ClaudeMessage {
+    if (typeof value !== 'object' || value === null) {
+      return false;
+    }
+
+    const obj = value as Record<string, unknown>;
+    const type = obj['type'];
+
+    if (type === 'system') {
+      return typeof obj['subtype'] === 'string';
+    }
+
+    if (type === 'assistant') {
+      const message = obj['message'];
+      if (typeof message !== 'object' || message === null) {
+        return false;
+      }
+      const msgObj = message as Record<string, unknown>;
+      return msgObj['type'] === 'text' || msgObj['type'] === 'tool_use';
+    }
+
+    if (type === 'user') {
+      const message = obj['message'];
+      if (typeof message !== 'object' || message === null) {
+        return false;
+      }
+      const msgObj = message as Record<string, unknown>;
+      return msgObj['type'] === 'tool_result';
+    }
+
+    return false;
+  }
+
+  /**
+   * Converts a ClaudeMessage to a ParsedEvent
+   */
+  private messageToEvent(
+    message: ClaudeMessage,
+    workOrderId: string,
+    runId: string
+  ): ParsedEvent | null {
+    if (message.type === 'system') {
+      // System messages are informational, don't emit events
+      return null;
+    }
+
+    if (message.type === 'assistant') {
+      if (message.message.type === 'tool_use') {
+        return this.parseToolUse(
+          message as ClaudeAssistantToolUseMessage,
+          workOrderId,
+          runId
+        );
+      }
+
+      if (message.message.type === 'text') {
+        return this.parseText(
+          message as ClaudeAssistantTextMessage,
+          workOrderId,
+          runId
+        );
+      }
+    }
+
+    if (message.type === 'user' && message.message.type === 'tool_result') {
+      return this.parseToolResult(message, workOrderId, runId);
+    }
+
+    return null;
+  }
+
+  /**
+   * Truncates content to the preview max length
+   */
+  private truncateContent(content: string): string {
+    if (content.length <= CONTENT_PREVIEW_MAX_LENGTH) {
+      return content;
+    }
+
+    return content.substring(0, CONTENT_PREVIEW_MAX_LENGTH) + '...';
+  }
+
+  /**
+   * Checks if we should emit a progress update and returns it
+   */
+  private maybeEmitProgress(
+    workOrderId: string,
+    runId: string
+  ): ProgressUpdateEvent | null {
+    const now = Date.now();
+
+    if (now - this.lastProgressTime >= this.progressIntervalMs) {
+      this.lastProgressTime = now;
+
+      // Determine current phase based on state
+      const phase = this.activeToolCalls.size > 0
+        ? 'Executing tools'
+        : 'Processing';
+
+      return this.createProgressEvent(workOrderId, runId, phase);
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the current tool call count
+   */
+  getToolCallCount(): number {
+    return this.toolCallCount;
+  }
+
+  /**
+   * Resets the parser state
+   */
+  reset(): void {
+    this.activeToolCalls.clear();
+    this.toolCallCount = 0;
+    this.startTime = null;
+    this.lastProgressTime = 0;
+  }
+}

--- a/packages/server/test/stream-parser.test.ts
+++ b/packages/server/test/stream-parser.test.ts
@@ -1,0 +1,740 @@
+/**
+ * Stream Parser Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Readable } from 'node:stream';
+import { createInterface } from 'node:readline';
+import {
+  StreamParser,
+  type ClaudeAssistantToolUseMessage,
+  type ClaudeAssistantTextMessage,
+  type ClaudeToolResultMessage,
+  type ParsedEvent,
+} from '../src/agent/stream-parser.js';
+
+describe('StreamParser', () => {
+  let parser: StreamParser;
+  const workOrderId = 'wo-123';
+  const runId = 'run-456';
+
+  beforeEach(() => {
+    parser = new StreamParser({ debug: false });
+  });
+
+  describe('parseLine', () => {
+    it('should handle valid JSON', () => {
+      const line = JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        cwd: '/workspace',
+      });
+
+      const result = parser.parseLine(line);
+
+      expect(result).toEqual({
+        type: 'system',
+        subtype: 'init',
+        cwd: '/workspace',
+      });
+    });
+
+    it('should return null for invalid JSON', () => {
+      const result = parser.parseLine('not valid json {{{');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty lines', () => {
+      expect(parser.parseLine('')).toBeNull();
+      expect(parser.parseLine('   ')).toBeNull();
+      expect(parser.parseLine('\n')).toBeNull();
+    });
+
+    it('should return null for unknown types', () => {
+      const line = JSON.stringify({
+        type: 'unknown_type',
+        data: 'some data',
+      });
+
+      const result = parser.parseLine(line);
+
+      expect(result).toBeNull();
+    });
+
+    it('should parse assistant text message', () => {
+      const line = JSON.stringify({
+        type: 'assistant',
+        message: {
+          type: 'text',
+          text: 'Hello, I will help you.',
+        },
+      });
+
+      const result = parser.parseLine(line);
+
+      expect(result).toEqual({
+        type: 'assistant',
+        message: {
+          type: 'text',
+          text: 'Hello, I will help you.',
+        },
+      });
+    });
+
+    it('should parse assistant tool_use message', () => {
+      const line = JSON.stringify({
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_01',
+          name: 'Read',
+          input: { file_path: '/workspace/src/index.ts' },
+        },
+      });
+
+      const result = parser.parseLine(line);
+
+      expect(result).toEqual({
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_01',
+          name: 'Read',
+          input: { file_path: '/workspace/src/index.ts' },
+        },
+      });
+    });
+
+    it('should parse user tool_result message', () => {
+      const line = JSON.stringify({
+        type: 'user',
+        message: {
+          type: 'tool_result',
+          tool_use_id: 'toolu_01',
+          content: 'File contents here...',
+        },
+      });
+
+      const result = parser.parseLine(line);
+
+      expect(result).toEqual({
+        type: 'user',
+        message: {
+          type: 'tool_result',
+          tool_use_id: 'toolu_01',
+          content: 'File contents here...',
+        },
+      });
+    });
+  });
+
+  describe('parseToolUse', () => {
+    it('should parse Read tool call', () => {
+      const message: ClaudeAssistantToolUseMessage = {
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_read_01',
+          name: 'Read',
+          input: { file_path: '/workspace/README.md' },
+        },
+      };
+
+      const event = parser.parseToolUse(message, workOrderId, runId);
+
+      expect(event.type).toBe('agent_tool_call');
+      expect(event.workOrderId).toBe(workOrderId);
+      expect(event.runId).toBe(runId);
+      expect(event.toolUseId).toBe('toolu_read_01');
+      expect(event.tool).toBe('Read');
+      expect(event.input).toEqual({ file_path: '/workspace/README.md' });
+      expect(event.timestamp).toBeDefined();
+    });
+
+    it('should parse Write tool call', () => {
+      const message: ClaudeAssistantToolUseMessage = {
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_write_01',
+          name: 'Write',
+          input: { file_path: '/workspace/new.ts', content: 'export const x = 1;' },
+        },
+      };
+
+      const event = parser.parseToolUse(message, workOrderId, runId);
+
+      expect(event.tool).toBe('Write');
+      expect(event.input).toEqual({ file_path: '/workspace/new.ts', content: 'export const x = 1;' });
+    });
+
+    it('should parse Bash tool call with command', () => {
+      const message: ClaudeAssistantToolUseMessage = {
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_bash_01',
+          name: 'Bash',
+          input: { command: 'npm install', timeout: 60000 },
+        },
+      };
+
+      const event = parser.parseToolUse(message, workOrderId, runId);
+
+      expect(event.tool).toBe('Bash');
+      expect(event.input).toEqual({ command: 'npm install', timeout: 60000 });
+    });
+
+    it('should extract tool use ID', () => {
+      const message: ClaudeAssistantToolUseMessage = {
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'unique_tool_id_123',
+          name: 'Grep',
+          input: { pattern: 'TODO' },
+        },
+      };
+
+      const event = parser.parseToolUse(message, workOrderId, runId);
+
+      expect(event.toolUseId).toBe('unique_tool_id_123');
+    });
+
+    it('should handle unknown tool as Other', () => {
+      const message: ClaudeAssistantToolUseMessage = {
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_unknown_01',
+          name: 'CustomTool',
+          input: { foo: 'bar' },
+        },
+      };
+
+      const event = parser.parseToolUse(message, workOrderId, runId);
+
+      expect(event.tool).toBe('Other');
+    });
+
+    it('should handle missing input fields', () => {
+      const message: ClaudeAssistantToolUseMessage = {
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_01',
+          name: 'Read',
+          input: {},
+        },
+      };
+
+      const event = parser.parseToolUse(message, workOrderId, runId);
+
+      expect(event.input).toEqual({});
+    });
+
+    it('should increment tool call count', () => {
+      const message: ClaudeAssistantToolUseMessage = {
+        type: 'assistant',
+        message: {
+          type: 'tool_use',
+          id: 'toolu_01',
+          name: 'Read',
+          input: {},
+        },
+      };
+
+      expect(parser.getToolCallCount()).toBe(0);
+
+      parser.parseToolUse(message, workOrderId, runId);
+      expect(parser.getToolCallCount()).toBe(1);
+
+      parser.parseToolUse(
+        { ...message, message: { ...message.message, id: 'toolu_02' } },
+        workOrderId,
+        runId
+      );
+      expect(parser.getToolCallCount()).toBe(2);
+    });
+  });
+
+  describe('parseToolResult', () => {
+    it('should parse successful result', () => {
+      // First, simulate a tool call to track timing
+      parser.parseToolUse(
+        {
+          type: 'assistant',
+          message: { type: 'tool_use', id: 'toolu_01', name: 'Read', input: {} },
+        },
+        workOrderId,
+        runId
+      );
+
+      const message: ClaudeToolResultMessage = {
+        type: 'user',
+        message: {
+          type: 'tool_result',
+          tool_use_id: 'toolu_01',
+          content: 'File contents successfully read.',
+        },
+      };
+
+      const event = parser.parseToolResult(message, workOrderId, runId);
+
+      expect(event.type).toBe('agent_tool_result');
+      expect(event.workOrderId).toBe(workOrderId);
+      expect(event.runId).toBe(runId);
+      expect(event.toolUseId).toBe('toolu_01');
+      expect(event.success).toBe(true);
+      expect(event.contentPreview).toBe('File contents successfully read.');
+      expect(event.contentLength).toBe(32);
+      expect(event.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should parse error result', () => {
+      const message: ClaudeToolResultMessage = {
+        type: 'user',
+        message: {
+          type: 'tool_result',
+          tool_use_id: 'toolu_error_01',
+          content: 'Error: File not found',
+          is_error: true,
+        },
+      };
+
+      const event = parser.parseToolResult(message, workOrderId, runId);
+
+      expect(event.success).toBe(false);
+      expect(event.contentPreview).toBe('Error: File not found');
+    });
+
+    it('should truncate long content', () => {
+      const longContent = 'x'.repeat(600);
+      const message: ClaudeToolResultMessage = {
+        type: 'user',
+        message: {
+          type: 'tool_result',
+          tool_use_id: 'toolu_01',
+          content: longContent,
+        },
+      };
+
+      const event = parser.parseToolResult(message, workOrderId, runId);
+
+      expect(event.contentPreview.length).toBe(503); // 500 + '...'
+      expect(event.contentPreview.endsWith('...')).toBe(true);
+      expect(event.contentLength).toBe(600);
+    });
+
+    it('should track content length', () => {
+      const content = 'Short content';
+      const message: ClaudeToolResultMessage = {
+        type: 'user',
+        message: {
+          type: 'tool_result',
+          tool_use_id: 'toolu_01',
+          content,
+        },
+      };
+
+      const event = parser.parseToolResult(message, workOrderId, runId);
+
+      expect(event.contentLength).toBe(content.length);
+    });
+
+    it('should correlate with tool call ID', () => {
+      const toolUseId = 'correlation_test_id';
+      const message: ClaudeToolResultMessage = {
+        type: 'user',
+        message: {
+          type: 'tool_result',
+          tool_use_id: toolUseId,
+          content: 'Result',
+        },
+      };
+
+      const event = parser.parseToolResult(message, workOrderId, runId);
+
+      expect(event.toolUseId).toBe(toolUseId);
+    });
+  });
+
+  describe('parseText', () => {
+    it('should extract assistant text', () => {
+      const message: ClaudeAssistantTextMessage = {
+        type: 'assistant',
+        message: {
+          type: 'text',
+          text: 'I will help you implement this feature.',
+        },
+      };
+
+      const event = parser.parseText(message, workOrderId, runId);
+
+      expect(event).not.toBeNull();
+      expect(event!.type).toBe('agent_output');
+      expect(event!.workOrderId).toBe(workOrderId);
+      expect(event!.runId).toBe(runId);
+      expect(event!.content).toBe('I will help you implement this feature.');
+    });
+
+    it('should handle empty text', () => {
+      const message: ClaudeAssistantTextMessage = {
+        type: 'assistant',
+        message: {
+          type: 'text',
+          text: '',
+        },
+      };
+
+      const event = parser.parseText(message, workOrderId, runId);
+
+      expect(event).toBeNull();
+    });
+
+    it('should handle whitespace-only text', () => {
+      const message: ClaudeAssistantTextMessage = {
+        type: 'assistant',
+        message: {
+          type: 'text',
+          text: '   \n\t   ',
+        },
+      };
+
+      const event = parser.parseText(message, workOrderId, runId);
+
+      expect(event).toBeNull();
+    });
+  });
+
+  describe('parseStream', () => {
+    function createReadline(lines: string[]): ReturnType<typeof createInterface> {
+      const stream = Readable.from(lines.map(line => line + '\n'));
+      return createInterface({ input: stream });
+    }
+
+    it('should yield events in order', async () => {
+      const lines = [
+        JSON.stringify({ type: 'system', subtype: 'init', cwd: '/workspace' }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { type: 'text', text: 'Starting...' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { type: 'tool_use', id: 'toolu_01', name: 'Read', input: { file_path: '/test.ts' } },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { type: 'tool_result', tool_use_id: 'toolu_01', content: 'file contents' },
+        }),
+      ];
+
+      const readline = createReadline(lines);
+      const events: ParsedEvent[] = [];
+
+      for await (const event of parser.parseStream(readline, workOrderId, runId)) {
+        events.push(event);
+      }
+
+      // Filter out progress updates
+      const nonProgressEvents = events.filter(e => e.type !== 'progress_update');
+
+      expect(nonProgressEvents.length).toBe(3);
+      expect(nonProgressEvents[0].type).toBe('agent_output');
+      expect(nonProgressEvents[1].type).toBe('agent_tool_call');
+      expect(nonProgressEvents[2].type).toBe('agent_tool_result');
+    });
+
+    it('should track tool call timing', async () => {
+      const lines = [
+        JSON.stringify({
+          type: 'assistant',
+          message: { type: 'tool_use', id: 'toolu_timing', name: 'Bash', input: { command: 'ls' } },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: { type: 'tool_result', tool_use_id: 'toolu_timing', content: 'file1\nfile2' },
+        }),
+      ];
+
+      const readline = createReadline(lines);
+      const events: ParsedEvent[] = [];
+
+      for await (const event of parser.parseStream(readline, workOrderId, runId)) {
+        events.push(event);
+      }
+
+      const resultEvent = events.find(e => e.type === 'agent_tool_result');
+      expect(resultEvent).toBeDefined();
+      expect((resultEvent as { durationMs: number }).durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should emit progress updates when interval elapsed', async () => {
+      // Use extremely short progress interval for testing
+      const fastParser = new StreamParser({ progressIntervalMs: 0 });
+
+      // Multiple lines to ensure we get a chance for progress emission
+      const lines = [
+        JSON.stringify({
+          type: 'assistant',
+          message: { type: 'text', text: 'Working...' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { type: 'tool_use', id: 'toolu_01', name: 'Read', input: {} },
+        }),
+      ];
+
+      const readline = createReadline(lines);
+      const events: ParsedEvent[] = [];
+
+      for await (const event of fastParser.parseStream(readline, workOrderId, runId)) {
+        events.push(event);
+      }
+
+      // Should have both text output and tool call events
+      expect(events.some(e => e.type === 'agent_output')).toBe(true);
+      expect(events.some(e => e.type === 'agent_tool_call')).toBe(true);
+    });
+
+    it('should handle stream errors gracefully', async () => {
+      const lines = [
+        'invalid json {{{',
+        JSON.stringify({
+          type: 'assistant',
+          message: { type: 'text', text: 'Still working' },
+        }),
+      ];
+
+      const readline = createReadline(lines);
+      const events: ParsedEvent[] = [];
+
+      // Should not throw, should skip invalid line
+      for await (const event of parser.parseStream(readline, workOrderId, runId)) {
+        events.push(event);
+      }
+
+      const nonProgressEvents = events.filter(e => e.type !== 'progress_update');
+      expect(nonProgressEvents.length).toBe(1);
+      expect(nonProgressEvents[0].type).toBe('agent_output');
+    });
+  });
+
+  describe('createProgressEvent', () => {
+    it('should create progress event with correct fields', () => {
+      const event = parser.createProgressEvent(workOrderId, runId, 'Reading files');
+
+      expect(event.type).toBe('progress_update');
+      expect(event.workOrderId).toBe(workOrderId);
+      expect(event.runId).toBe(runId);
+      expect(event.currentPhase).toBe('Reading files');
+      expect(event.percentage).toBeGreaterThanOrEqual(0);
+      expect(event.percentage).toBeLessThanOrEqual(100);
+      expect(event.toolCallCount).toBe(0);
+      expect(event.elapsedSeconds).toBeGreaterThanOrEqual(0);
+      expect(event.timestamp).toBeDefined();
+    });
+
+    it('should increment percentage with tool calls', () => {
+      // Make some tool calls
+      parser.parseToolUse(
+        { type: 'assistant', message: { type: 'tool_use', id: '1', name: 'Read', input: {} } },
+        workOrderId,
+        runId
+      );
+      parser.parseToolUse(
+        { type: 'assistant', message: { type: 'tool_use', id: '2', name: 'Read', input: {} } },
+        workOrderId,
+        runId
+      );
+
+      const event = parser.createProgressEvent(workOrderId, runId, 'Processing');
+
+      expect(event.toolCallCount).toBe(2);
+      expect(event.percentage).toBe(10); // 2 * 5 = 10
+    });
+
+    it('should cap percentage at 95', () => {
+      // Make many tool calls
+      for (let i = 0; i < 25; i++) {
+        parser.parseToolUse(
+          { type: 'assistant', message: { type: 'tool_use', id: `id_${i}`, name: 'Read', input: {} } },
+          workOrderId,
+          runId
+        );
+      }
+
+      const event = parser.createProgressEvent(workOrderId, runId, 'Processing');
+
+      expect(event.percentage).toBe(95);
+    });
+  });
+
+  describe('factory methods', () => {
+    it('should create tool call event with all fields', () => {
+      const event = parser.createToolCallEvent(workOrderId, runId, {
+        toolUseId: 'test_id',
+        tool: 'Edit',
+        input: { file_path: '/test.ts', old_string: 'a', new_string: 'b' },
+      });
+
+      expect(event.type).toBe('agent_tool_call');
+      expect(event.workOrderId).toBe(workOrderId);
+      expect(event.runId).toBe(runId);
+      expect(event.toolUseId).toBe('test_id');
+      expect(event.tool).toBe('Edit');
+      expect(event.input).toEqual({ file_path: '/test.ts', old_string: 'a', new_string: 'b' });
+      expect(event.timestamp).toBeDefined();
+    });
+
+    it('should create tool result event with all fields', () => {
+      const event = parser.createToolResultEvent(workOrderId, runId, {
+        toolUseId: 'result_id',
+        success: true,
+        content: 'Operation completed',
+        durationMs: 150,
+      });
+
+      expect(event.type).toBe('agent_tool_result');
+      expect(event.workOrderId).toBe(workOrderId);
+      expect(event.runId).toBe(runId);
+      expect(event.toolUseId).toBe('result_id');
+      expect(event.success).toBe(true);
+      expect(event.contentPreview).toBe('Operation completed');
+      expect(event.contentLength).toBe(19);
+      expect(event.durationMs).toBe(150);
+      expect(event.timestamp).toBeDefined();
+    });
+
+    it('should create output event with all fields', () => {
+      const event = parser.createOutputEvent(workOrderId, runId, 'Agent thinking...');
+
+      expect(event.type).toBe('agent_output');
+      expect(event.workOrderId).toBe(workOrderId);
+      expect(event.runId).toBe(runId);
+      expect(event.content).toBe('Agent thinking...');
+      expect(event.timestamp).toBeDefined();
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset all internal state', () => {
+      // Add some state
+      parser.parseToolUse(
+        { type: 'assistant', message: { type: 'tool_use', id: '1', name: 'Read', input: {} } },
+        workOrderId,
+        runId
+      );
+
+      expect(parser.getToolCallCount()).toBe(1);
+
+      parser.reset();
+
+      expect(parser.getToolCallCount()).toBe(0);
+    });
+  });
+});
+
+describe('AgentEventTypes', () => {
+  it('should include all new types in ServerMessage', async () => {
+    // Type-level test: import and verify types exist
+    const types = await import('../src/server/websocket/types.js');
+
+    // Verify the types exist by checking they're defined
+    expect(types.WebSocketErrorCode).toBeDefined();
+
+    // The following would cause compile errors if types are missing
+    // This is a runtime check that the module exports exist
+    const serverMessageTypeTest: types.ServerMessage = {
+      type: 'agent_tool_call',
+      workOrderId: 'wo-1',
+      runId: 'run-1',
+      toolUseId: 'toolu_1',
+      tool: 'Read',
+      input: {},
+      timestamp: new Date().toISOString(),
+    };
+    expect(serverMessageTypeTest.type).toBe('agent_tool_call');
+  });
+
+  it('should validate AgentToolCallEvent structure', async () => {
+    const types = await import('../src/server/websocket/types.js');
+
+    const event: types.AgentToolCallEvent = {
+      type: 'agent_tool_call',
+      workOrderId: 'wo-123',
+      runId: 'run-456',
+      toolUseId: 'toolu_abc',
+      tool: 'Read',
+      input: { file_path: '/test.ts' },
+      timestamp: '2024-01-01T00:00:00.000Z',
+    };
+
+    expect(event.type).toBe('agent_tool_call');
+    expect(event.workOrderId).toBe('wo-123');
+    expect(event.runId).toBe('run-456');
+    expect(event.toolUseId).toBe('toolu_abc');
+    expect(event.tool).toBe('Read');
+    expect(event.input).toEqual({ file_path: '/test.ts' });
+    expect(event.timestamp).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('should validate AgentToolResultEvent structure', async () => {
+    const types = await import('../src/server/websocket/types.js');
+
+    const event: types.AgentToolResultEvent = {
+      type: 'agent_tool_result',
+      workOrderId: 'wo-123',
+      runId: 'run-456',
+      toolUseId: 'toolu_abc',
+      success: true,
+      contentPreview: 'File contents...',
+      contentLength: 1024,
+      durationMs: 50,
+      timestamp: '2024-01-01T00:00:00.000Z',
+    };
+
+    expect(event.type).toBe('agent_tool_result');
+    expect(event.success).toBe(true);
+    expect(event.contentPreview).toBe('File contents...');
+    expect(event.contentLength).toBe(1024);
+    expect(event.durationMs).toBe(50);
+  });
+
+  it('should validate SubscribeMessage with filters', async () => {
+    const types = await import('../src/server/websocket/types.js');
+
+    // Parse with filters
+    const messageWithFilters = {
+      type: 'subscribe' as const,
+      workOrderId: 'wo-123',
+      filters: {
+        includeToolCalls: true,
+        includeToolResults: false,
+        includeOutput: true,
+        includeFileChanges: false,
+        includeProgress: true,
+      },
+    };
+
+    const parsed = types.subscribeMessageSchema.safeParse(messageWithFilters);
+    expect(parsed.success).toBe(true);
+
+    if (parsed.success) {
+      expect(parsed.data.filters?.includeToolCalls).toBe(true);
+      expect(parsed.data.filters?.includeToolResults).toBe(false);
+    }
+
+    // Parse without filters (should use defaults)
+    const messageWithoutFilters = {
+      type: 'subscribe' as const,
+      workOrderId: 'wo-456',
+    };
+
+    const parsedWithoutFilters = types.subscribeMessageSchema.safeParse(messageWithoutFilters);
+    expect(parsedWithoutFilters.success).toBe(true);
+    expect(parsedWithoutFilters.data?.filters).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Thrust 1**: Add agent event types to `packages/server/src/server/websocket/types.ts`
  - `AgentToolCallEvent`: Emitted when the agent invokes a tool (Read, Write, Edit, Bash, etc.)
  - `AgentToolResultEvent`: Emitted when tool execution completes with success/failure status
  - `AgentOutputEvent`: Emitted when the agent produces text output
  - `FileChangedEvent`: Emitted when files are created/modified/deleted in workspace
  - `ProgressUpdateEvent`: Emitted for progress updates during agent execution
  - Updated `ServerMessage` union to include all new event types
  - Added subscription filter options (`includeToolCalls`, `includeToolResults`, etc.)

- **Thrust 2**: Create `packages/server/src/agent/stream-parser.ts`
  - `StreamParser` class that parses Claude Code JSON output lines
  - Handles `tool_use`, `tool_result`, and `text` events from Claude Code
  - Factory methods for creating typed events with all required fields
  - Async generator `parseStream()` for streaming interface
  - Progress estimation based on tool call count and elapsed time
  - Tracks tool call timing for duration calculation

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (only pre-existing warning in run-executor.ts)
- [x] `pnpm test` passes (416 tests)
- [x] Comprehensive unit tests in `packages/server/test/stream-parser.test.ts`:
  - Parsing valid tool_use JSON
  - Parsing valid tool_result JSON
  - Parsing text output
  - Handling malformed JSON
  - Handling unknown event types
  - Stream processing with async generator
  - Progress update generation

## Files Changed

| File | Action |
|------|--------|
| `packages/server/src/server/websocket/types.ts` | Modified - Added 5 new event interfaces and subscription filters |
| `packages/server/src/agent/stream-parser.ts` | Created - StreamParser class (~500 lines) |
| `packages/server/test/stream-parser.test.ts` | Created - Unit tests (~740 lines) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)