### PR TITLE
feat: add GitHub Actions client and workflow types (v0.2.12 Thrusts 1-2)

### DIFF
--- a/packages/server/src/github/actions-client.ts
+++ b/packages/server/src/github/actions-client.ts
@@ -1,0 +1,386 @@
+/**
+ * GitHub Actions API client for interacting with workflow runs
+ */
+import { Octokit } from '@octokit/rest';
+import { createLogger } from '../utils/logger.js';
+import type {
+  WorkflowRun,
+  WorkflowJob,
+  WorkflowStep,
+  ListWorkflowRunsOptions,
+  ListWorkflowRunsResponse,
+  ListWorkflowJobsResponse,
+} from '@agentgate/shared';
+
+const logger = createLogger('github:actions-client');
+
+/**
+ * Error thrown when GitHub Actions API operations fail
+ */
+export class GitHubActionsError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly cause?: Error
+  ) {
+    super(message);
+    this.name = 'GitHubActionsError';
+  }
+}
+
+/**
+ * Configuration options for GitHubActionsClient
+ */
+export interface GitHubActionsClientOptions {
+  /** GitHub personal access token. Falls back to GITHUB_TOKEN env var */
+  token?: string;
+  /** Pre-configured Octokit instance */
+  octokit?: Octokit;
+}
+
+/**
+ * Client for interacting with GitHub Actions API
+ *
+ * Provides methods for:
+ * - Listing workflow runs
+ * - Getting workflow run details
+ * - Listing jobs for a workflow run
+ * - Downloading workflow logs
+ * - Finding workflow runs for pull requests
+ */
+export class GitHubActionsClient {
+  private readonly octokit: Octokit;
+
+  constructor(options: GitHubActionsClientOptions = {}) {
+    if (options.octokit) {
+      this.octokit = options.octokit;
+    } else {
+      const token = options.token ?? process.env['GITHUB_TOKEN'];
+      if (!token) {
+        throw new GitHubActionsError(
+          'GitHub token is required. Provide token option or set GITHUB_TOKEN environment variable.'
+        );
+      }
+      this.octokit = new Octokit({ auth: token });
+    }
+  }
+
+  /**
+   * List workflow runs for a repository
+   *
+   * @param owner - Repository owner (user or organization)
+   * @param repo - Repository name
+   * @param options - Filter and pagination options
+   * @returns List of workflow runs with total count
+   */
+  async listWorkflowRuns(
+    owner: string,
+    repo: string,
+    options: ListWorkflowRunsOptions = {}
+  ): Promise<ListWorkflowRunsResponse> {
+    logger.debug({ owner, repo, options }, 'Listing workflow runs');
+
+    try {
+      const response = await this.octokit.actions.listWorkflowRunsForRepo({
+        owner,
+        repo,
+        branch: options.branch,
+        event: options.event,
+        status: options.status as
+          | 'completed'
+          | 'action_required'
+          | 'cancelled'
+          | 'failure'
+          | 'neutral'
+          | 'skipped'
+          | 'stale'
+          | 'success'
+          | 'timed_out'
+          | 'in_progress'
+          | 'queued'
+          | 'requested'
+          | 'waiting'
+          | 'pending'
+          | undefined,
+        per_page: options.per_page ?? 30,
+        page: options.page ?? 1,
+        exclude_pull_requests: options.exclude_pull_requests,
+        created: options.created,
+        head_sha: options.head_sha,
+      });
+
+      const workflowRuns: WorkflowRun[] = response.data.workflow_runs.map((run) =>
+        this.mapWorkflowRun(run)
+      );
+
+      return {
+        total_count: response.data.total_count,
+        workflow_runs: workflowRuns,
+      };
+    } catch (error) {
+      throw this.handleError('Failed to list workflow runs', error);
+    }
+  }
+
+  /**
+   * Get details for a specific workflow run
+   *
+   * @param owner - Repository owner
+   * @param repo - Repository name
+   * @param runId - Workflow run ID
+   * @returns Workflow run details
+   */
+  async getWorkflowRun(owner: string, repo: string, runId: number): Promise<WorkflowRun> {
+    logger.debug({ owner, repo, runId }, 'Getting workflow run');
+
+    try {
+      const response = await this.octokit.actions.getWorkflowRun({
+        owner,
+        repo,
+        run_id: runId,
+      });
+
+      return this.mapWorkflowRun(response.data);
+    } catch (error) {
+      throw this.handleError(`Failed to get workflow run ${runId}`, error);
+    }
+  }
+
+  /**
+   * List jobs for a workflow run
+   *
+   * @param owner - Repository owner
+   * @param repo - Repository name
+   * @param runId - Workflow run ID
+   * @returns List of jobs with their steps
+   */
+  async listJobsForRun(
+    owner: string,
+    repo: string,
+    runId: number
+  ): Promise<ListWorkflowJobsResponse> {
+    logger.debug({ owner, repo, runId }, 'Listing jobs for workflow run');
+
+    try {
+      const response = await this.octokit.actions.listJobsForWorkflowRun({
+        owner,
+        repo,
+        run_id: runId,
+        per_page: 100,
+      });
+
+      const jobs: WorkflowJob[] = response.data.jobs.map((job) => this.mapWorkflowJob(job));
+
+      return {
+        total_count: response.data.total_count,
+        jobs,
+      };
+    } catch (error) {
+      throw this.handleError(`Failed to list jobs for workflow run ${runId}`, error);
+    }
+  }
+
+  /**
+   * Download logs for a workflow run
+   *
+   * @param owner - Repository owner
+   * @param repo - Repository name
+   * @param runId - Workflow run ID
+   * @returns Raw log content as string
+   */
+  async downloadLogs(owner: string, repo: string, runId: number): Promise<string> {
+    logger.debug({ owner, repo, runId }, 'Downloading workflow run logs');
+
+    try {
+      const response = await this.octokit.actions.downloadWorkflowRunLogs({
+        owner,
+        repo,
+        run_id: runId,
+      });
+
+      // The response is a redirect URL to the logs archive
+      // Octokit follows the redirect and returns the data
+      if (typeof response.data === 'string') {
+        return response.data;
+      }
+
+      // If it's an ArrayBuffer, convert to string
+      if (response.data instanceof ArrayBuffer) {
+        return new TextDecoder().decode(response.data);
+      }
+
+      // Handle the case where data is returned as a URL (redirect)
+      if (response.url) {
+        logger.debug({ url: response.url }, 'Following redirect for logs');
+        const logsResponse = await fetch(response.url);
+        if (!logsResponse.ok) {
+          throw new GitHubActionsError(
+            `Failed to fetch logs from redirect URL: ${logsResponse.status}`
+          );
+        }
+        return await logsResponse.text();
+      }
+
+      throw new GitHubActionsError('Unexpected response format for workflow logs');
+    } catch (error) {
+      if (error instanceof GitHubActionsError) {
+        throw error;
+      }
+      throw this.handleError(`Failed to download logs for workflow run ${runId}`, error);
+    }
+  }
+
+  /**
+   * Find the most recent workflow run for a pull request
+   *
+   * @param owner - Repository owner
+   * @param repo - Repository name
+   * @param prNumber - Pull request number
+   * @returns Most recent workflow run matching the PR, or null if none found
+   */
+  async getRunForPR(owner: string, repo: string, prNumber: number): Promise<WorkflowRun | null> {
+    logger.debug({ owner, repo, prNumber }, 'Finding workflow run for PR');
+
+    try {
+      // First, get the PR to find the head SHA
+      const prResponse = await this.octokit.pulls.get({
+        owner,
+        repo,
+        pull_number: prNumber,
+      });
+
+      const headSha = prResponse.data.head.sha;
+      logger.debug({ prNumber, headSha }, 'Found PR head SHA');
+
+      // List workflow runs for this SHA
+      const runsResponse = await this.listWorkflowRuns(owner, repo, {
+        head_sha: headSha,
+        per_page: 10,
+      });
+
+      if (runsResponse.workflow_runs.length === 0) {
+        logger.debug({ prNumber, headSha }, 'No workflow runs found for PR');
+        return null;
+      }
+
+      // Return the most recent run (first in the list)
+      const run = runsResponse.workflow_runs[0];
+      if (run) {
+        logger.debug({ prNumber, runId: run.id }, 'Found workflow run for PR');
+        return run;
+      }
+
+      return null;
+    } catch (error) {
+      // Handle 404 for PR not found
+      if (this.isNotFoundError(error)) {
+        logger.debug({ prNumber }, 'PR not found');
+        return null;
+      }
+      throw this.handleError(`Failed to find workflow run for PR #${prNumber}`, error);
+    }
+  }
+
+  /**
+   * Map Octokit workflow run response to our WorkflowRun type
+   */
+  private mapWorkflowRun(run: Awaited<
+    ReturnType<typeof this.octokit.actions.getWorkflowRun>
+  >['data']): WorkflowRun {
+    return {
+      id: run.id,
+      name: run.name ?? null,
+      status: (run.status as WorkflowRun['status']) ?? null,
+      conclusion: (run.conclusion as WorkflowRun['conclusion']) ?? null,
+      head_sha: run.head_sha,
+      head_branch: run.head_branch ?? null,
+      event: run.event,
+      created_at: run.created_at,
+      updated_at: run.updated_at,
+      jobs_url: run.jobs_url,
+      logs_url: run.logs_url,
+      html_url: run.html_url,
+      run_number: run.run_number,
+      run_attempt: run.run_attempt ?? 1,
+      workflow_id: run.workflow_id,
+      repository_url: run.repository.url,
+    };
+  }
+
+  /**
+   * Map Octokit workflow job response to our WorkflowJob type
+   */
+  private mapWorkflowJob(job: Awaited<
+    ReturnType<typeof this.octokit.actions.listJobsForWorkflowRun>
+  >['data']['jobs'][number]): WorkflowJob {
+    const steps: WorkflowStep[] = (job.steps ?? []).map((step) => ({
+      name: step.name,
+      status: step.status as WorkflowStep['status'],
+      conclusion: (step.conclusion as WorkflowStep['conclusion']) ?? null,
+      number: step.number,
+      started_at: step.started_at ?? null,
+      completed_at: step.completed_at ?? null,
+    }));
+
+    return {
+      id: job.id,
+      name: job.name,
+      status: job.status as WorkflowJob['status'],
+      conclusion: (job.conclusion as WorkflowJob['conclusion']) ?? null,
+      started_at: job.started_at ?? null,
+      completed_at: job.completed_at ?? null,
+      steps,
+      html_url: job.html_url ?? '',
+      run_id: job.run_id,
+      runner_name: job.runner_name ?? null,
+    };
+  }
+
+  /**
+   * Check if an error is a 404 Not Found error
+   */
+  private isNotFoundError(error: unknown): boolean {
+    if (error && typeof error === 'object' && 'status' in error) {
+      return (error as { status: number }).status === 404;
+    }
+    return false;
+  }
+
+  /**
+   * Convert Octokit errors to GitHubActionsError
+   */
+  private handleError(message: string, error: unknown): GitHubActionsError {
+    logger.error({ error, message }, 'GitHub Actions API error');
+
+    if (error instanceof GitHubActionsError) {
+      return error;
+    }
+
+    if (error && typeof error === 'object') {
+      const octokitError = error as { status?: number; message?: string };
+      const statusCode = octokitError.status;
+      const errorMessage = octokitError.message ?? 'Unknown error';
+
+      if (statusCode === 404) {
+        return new GitHubActionsError(`${message}: Resource not found`, statusCode);
+      }
+      if (statusCode === 401) {
+        return new GitHubActionsError(`${message}: Authentication failed`, statusCode);
+      }
+      if (statusCode === 403) {
+        return new GitHubActionsError(
+          `${message}: Access denied (possibly rate limited)`,
+          statusCode
+        );
+      }
+
+      return new GitHubActionsError(`${message}: ${errorMessage}`, statusCode);
+    }
+
+    return new GitHubActionsError(
+      message,
+      undefined,
+      error instanceof Error ? error : undefined
+    );
+  }
+}

--- a/packages/server/src/github/index.ts
+++ b/packages/server/src/github/index.ts
@@ -1,0 +1,7 @@
+/**
+ * GitHub integration module
+ *
+ * Provides clients and utilities for interacting with GitHub APIs.
+ */
+export { GitHubActionsClient, GitHubActionsError } from './actions-client.js';
+export type { GitHubActionsClientOptions } from './actions-client.js';

--- a/packages/server/test-fixtures/toy-repo/test-change.txt
+++ b/packages/server/test-fixtures/toy-repo/test-change.txt
@@ -1,0 +1,1 @@
+Test content for snapshot

--- a/packages/shared/src/types/github-actions.ts
+++ b/packages/shared/src/types/github-actions.ts
@@ -1,0 +1,212 @@
+/**
+ * GitHub Actions workflow types for AgentGate
+ */
+
+/**
+ * Workflow run status values from GitHub Actions API
+ */
+export const WorkflowRunStatus = {
+  QUEUED: 'queued',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+  WAITING: 'waiting',
+  REQUESTED: 'requested',
+  PENDING: 'pending',
+} as const;
+
+export type WorkflowRunStatus = (typeof WorkflowRunStatus)[keyof typeof WorkflowRunStatus];
+
+/**
+ * Workflow run conclusion values from GitHub Actions API
+ */
+export const WorkflowRunConclusion = {
+  SUCCESS: 'success',
+  FAILURE: 'failure',
+  CANCELLED: 'cancelled',
+  SKIPPED: 'skipped',
+  TIMED_OUT: 'timed_out',
+  ACTION_REQUIRED: 'action_required',
+  STALE: 'stale',
+  NEUTRAL: 'neutral',
+} as const;
+
+export type WorkflowRunConclusion =
+  (typeof WorkflowRunConclusion)[keyof typeof WorkflowRunConclusion];
+
+/**
+ * Workflow job status values
+ */
+export const WorkflowJobStatus = {
+  QUEUED: 'queued',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+  WAITING: 'waiting',
+} as const;
+
+export type WorkflowJobStatus = (typeof WorkflowJobStatus)[keyof typeof WorkflowJobStatus];
+
+/**
+ * Workflow job conclusion values
+ */
+export const WorkflowJobConclusion = {
+  SUCCESS: 'success',
+  FAILURE: 'failure',
+  CANCELLED: 'cancelled',
+  SKIPPED: 'skipped',
+} as const;
+
+export type WorkflowJobConclusion =
+  (typeof WorkflowJobConclusion)[keyof typeof WorkflowJobConclusion];
+
+/**
+ * Workflow step status values
+ */
+export const WorkflowStepStatus = {
+  QUEUED: 'queued',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+} as const;
+
+export type WorkflowStepStatus = (typeof WorkflowStepStatus)[keyof typeof WorkflowStepStatus];
+
+/**
+ * Workflow step conclusion values
+ */
+export const WorkflowStepConclusion = {
+  SUCCESS: 'success',
+  FAILURE: 'failure',
+  CANCELLED: 'cancelled',
+  SKIPPED: 'skipped',
+} as const;
+
+export type WorkflowStepConclusion =
+  (typeof WorkflowStepConclusion)[keyof typeof WorkflowStepConclusion];
+
+/**
+ * Represents a step within a workflow job
+ */
+export interface WorkflowStep {
+  name: string;
+  status: WorkflowStepStatus;
+  conclusion: WorkflowStepConclusion | null;
+  number: number;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+/**
+ * Represents a job within a workflow run
+ */
+export interface WorkflowJob {
+  id: number;
+  name: string;
+  status: WorkflowJobStatus;
+  conclusion: WorkflowJobConclusion | null;
+  started_at: string | null;
+  completed_at: string | null;
+  steps: WorkflowStep[];
+  html_url: string;
+  run_id: number;
+  runner_name: string | null;
+}
+
+/**
+ * Represents a workflow run
+ */
+export interface WorkflowRun {
+  id: number;
+  name: string | null;
+  status: WorkflowRunStatus | null;
+  conclusion: WorkflowRunConclusion | null;
+  head_sha: string;
+  head_branch: string | null;
+  event: string;
+  created_at: string;
+  updated_at: string;
+  jobs_url: string;
+  logs_url: string;
+  html_url: string;
+  run_number: number;
+  run_attempt: number;
+  workflow_id: number;
+  repository_url: string;
+}
+
+/**
+ * CI failure type classification
+ */
+export const CIFailureType = {
+  BUILD: 'build',
+  LINT: 'lint',
+  TEST: 'test',
+  OTHER: 'other',
+} as const;
+
+export type CIFailureType = (typeof CIFailureType)[keyof typeof CIFailureType];
+
+/**
+ * Represents a CI failure with extracted context
+ */
+export interface CIFailure {
+  type: CIFailureType;
+  job: string;
+  step: string;
+  message: string;
+  file?: string;
+  line?: number;
+  context: string[];
+}
+
+/**
+ * CI result status values
+ */
+export const CIResultStatus = {
+  SUCCESS: 'success',
+  FAILURE: 'failure',
+  CANCELLED: 'cancelled',
+  PENDING: 'pending',
+} as const;
+
+export type CIResultStatus = (typeof CIResultStatus)[keyof typeof CIResultStatus];
+
+/**
+ * Aggregated CI result for a workflow run
+ */
+export interface CIResult {
+  status: CIResultStatus;
+  runId: number;
+  runUrl: string;
+  failures: CIFailure[];
+  duration: number;
+  jobs: WorkflowJob[];
+}
+
+/**
+ * Options for listing workflow runs
+ */
+export interface ListWorkflowRunsOptions {
+  branch?: string;
+  event?: string;
+  status?: WorkflowRunStatus | 'completed';
+  per_page?: number;
+  page?: number;
+  exclude_pull_requests?: boolean;
+  created?: string;
+  head_sha?: string;
+}
+
+/**
+ * Response from listing workflow runs
+ */
+export interface ListWorkflowRunsResponse {
+  total_count: number;
+  workflow_runs: WorkflowRun[];
+}
+
+/**
+ * Response from listing workflow jobs
+ */
+export interface ListWorkflowJobsResponse {
+  total_count: number;
+  jobs: WorkflowJob[];
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './work-order.js';
 export * from './run.js';
 export * from './api.js';
 export * from './websocket.js';
+export * from './github-actions.js';


### PR DESCRIPTION
## Summary
- Add GitHubActionsClient class wrapping Octokit for interacting with GitHub Actions API
- Implement methods for listing workflow runs, getting run details, listing jobs, downloading logs, and finding runs for PRs
- Add comprehensive TypeScript types for WorkflowRun, WorkflowJob, WorkflowStep, CIFailure, and CIResult
- Export types from shared package for cross-package type safety

## Test plan
- [ ] Verify `pnpm typecheck` passes
- [ ] Verify `pnpm lint` passes
- [ ] Verify `pnpm test` passes
- [ ] Manually test client instantiation with GITHUB_TOKEN
- [ ] Review error handling for 404s and auth failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)