### PR TITLE
feat: implement sandbox provider interface (v0.2.13 Thrusts 1-2)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,6 +31,7 @@
     "@octokit/rest": "^22.0.1",
     "@openai/codex-sdk": "^0.77.0",
     "@opencode-ai/sdk": "^1.0.218",
+    "adm-zip": "^0.5.16",
     "ajv": "^8.12.0",
     "commander": "^12.0.0",
     "dotenv": "^17.2.3",
@@ -45,6 +46,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.7",
     "@types/node": "^20.10.6",
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^6.17.0",

--- a/packages/server/src/sandbox/index.ts
+++ b/packages/server/src/sandbox/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Sandbox Module
+ *
+ * Provides pluggable sandbox providers for isolated agent execution.
+ */
+
+// Types
+export type {
+  NetworkMode,
+  ResourceLimits,
+  SandboxConfig,
+  SandboxStatus,
+  ExecOptions,
+  ExecResult,
+  SandboxStats,
+  Sandbox,
+  SandboxProvider,
+} from './types.js';
+
+// Base provider class and constants
+export {
+  BaseSandboxProvider,
+  DEFAULT_RESOURCE_LIMITS,
+  DEFAULT_WORKSPACE_MOUNT,
+} from './provider.js';
+
+// Subprocess provider (fallback, no isolation)
+export { SubprocessProvider } from './subprocess-provider.js';

--- a/packages/server/src/sandbox/provider.ts
+++ b/packages/server/src/sandbox/provider.ts
@@ -1,0 +1,117 @@
+/**
+ * Base Sandbox Provider
+ *
+ * Abstract base class implementing common functionality for sandbox providers.
+ */
+
+import type { Logger } from 'pino';
+import { createLogger } from '../utils/logger.js';
+import type {
+  Sandbox,
+  SandboxConfig,
+  SandboxProvider,
+  ResourceLimits,
+} from './types.js';
+
+/**
+ * Default resource limits applied when not specified in config.
+ */
+export const DEFAULT_RESOURCE_LIMITS: Required<ResourceLimits> = {
+  cpuCount: 2,
+  memoryMB: 2048,
+  diskMB: 10240,
+  timeoutSeconds: 300,
+};
+
+/**
+ * Default workspace mount path inside container.
+ */
+export const DEFAULT_WORKSPACE_MOUNT = '/workspace';
+
+/**
+ * Abstract base class for sandbox providers.
+ *
+ * Provides common functionality like logging, default resource limits,
+ * and error handling utilities.
+ */
+export abstract class BaseSandboxProvider implements SandboxProvider {
+  abstract readonly name: string;
+
+  protected readonly logger: Logger;
+  protected readonly activeSandboxes: Map<string, Sandbox> = new Map();
+
+  constructor() {
+    this.logger = createLogger(`sandbox:${this.getProviderName()}`);
+  }
+
+  /**
+   * Subclasses must implement to return provider name for logger initialization.
+   */
+  protected abstract getProviderName(): string;
+
+  abstract isAvailable(): Promise<boolean>;
+  abstract createSandbox(config: SandboxConfig): Promise<Sandbox>;
+
+  /**
+   * List all active sandboxes managed by this provider.
+   */
+  listSandboxes(): Promise<Sandbox[]> {
+    return Promise.resolve(Array.from(this.activeSandboxes.values()));
+  }
+
+  /**
+   * Clean up all active sandboxes.
+   */
+  async cleanup(): Promise<void> {
+    this.logger.info(
+      { count: this.activeSandboxes.size },
+      'Cleaning up sandboxes'
+    );
+
+    const destroyPromises: Promise<void>[] = [];
+
+    for (const sandbox of this.activeSandboxes.values()) {
+      destroyPromises.push(
+        sandbox.destroy().catch((err: unknown) => {
+          this.logger.error(
+            { sandboxId: sandbox.id, err },
+            'Failed to destroy sandbox during cleanup'
+          );
+        })
+      );
+    }
+
+    await Promise.all(destroyPromises);
+    this.activeSandboxes.clear();
+  }
+
+  /**
+   * Apply default resource limits to a config.
+   */
+  protected applyDefaults(config: SandboxConfig): SandboxConfig {
+    return {
+      ...config,
+      workspaceMount: config.workspaceMount ?? DEFAULT_WORKSPACE_MOUNT,
+      resourceLimits: {
+        ...DEFAULT_RESOURCE_LIMITS,
+        ...config.resourceLimits,
+      },
+    };
+  }
+
+  /**
+   * Register a sandbox with this provider.
+   */
+  protected registerSandbox(sandbox: Sandbox): void {
+    this.activeSandboxes.set(sandbox.id, sandbox);
+    this.logger.debug({ sandboxId: sandbox.id }, 'Registered sandbox');
+  }
+
+  /**
+   * Unregister a sandbox from this provider.
+   */
+  protected unregisterSandbox(sandboxId: string): void {
+    this.activeSandboxes.delete(sandboxId);
+    this.logger.debug({ sandboxId }, 'Unregistered sandbox');
+  }
+}

--- a/packages/server/src/sandbox/subprocess-provider.ts
+++ b/packages/server/src/sandbox/subprocess-provider.ts
@@ -1,0 +1,257 @@
+/**
+ * Subprocess Sandbox Provider
+ *
+ * A subprocess-based provider that maintains backward compatibility
+ * and serves as a fallback when Docker is unavailable. This provider
+ * offers no isolation - processes run directly on the host.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { BaseSandboxProvider } from './provider.js';
+import type {
+  Sandbox,
+  SandboxConfig,
+  SandboxStatus,
+  SandboxStats,
+  ExecOptions,
+  ExecResult,
+} from './types.js';
+
+/**
+ * Generate a unique sandbox ID.
+ */
+function generateSandboxId(): string {
+  return `subprocess-${randomBytes(8).toString('hex')}`;
+}
+
+/**
+ * Validate that a path stays within the workspace directory.
+ * Prevents path traversal attacks.
+ */
+function validatePath(workspacePath: string, relativePath: string): string {
+  const normalizedWorkspace = path.resolve(workspacePath);
+  const fullPath = path.resolve(workspacePath, relativePath);
+
+  if (!fullPath.startsWith(normalizedWorkspace + path.sep) && fullPath !== normalizedWorkspace) {
+    throw new Error(`Path traversal detected: ${relativePath}`);
+  }
+
+  return fullPath;
+}
+
+/**
+ * Subprocess-based sandbox implementation.
+ *
+ * Executes commands directly on the host using child_process.spawn.
+ * Provides no isolation but implements the Sandbox interface for compatibility.
+ */
+class SubprocessSandbox implements Sandbox {
+  readonly id: string;
+  status: SandboxStatus;
+  containerId?: string;
+
+  private readonly workspacePath: string;
+  private readonly env: Record<string, string>;
+  private readonly defaultTimeout: number;
+  private currentProcess: ChildProcess | null = null;
+  private readonly onDestroy: (id: string) => void;
+
+  constructor(
+    id: string,
+    workspacePath: string,
+    env: Record<string, string>,
+    defaultTimeout: number,
+    onDestroy: (id: string) => void
+  ) {
+    this.id = id;
+    this.workspacePath = workspacePath;
+    this.env = env;
+    this.defaultTimeout = defaultTimeout;
+    this.onDestroy = onDestroy;
+    this.status = 'running';
+  }
+
+  async execute(
+    command: string,
+    args: string[],
+    options?: ExecOptions
+  ): Promise<ExecResult> {
+    if (this.status !== 'running') {
+      throw new Error(`Sandbox is not running (status: ${this.status})`);
+    }
+
+    const cwd = options?.cwd
+      ? validatePath(this.workspacePath, options.cwd)
+      : this.workspacePath;
+
+    const timeout = (options?.timeout ?? this.defaultTimeout) * 1000;
+    const env = {
+      ...process.env,
+      ...this.env,
+      ...options?.env,
+    };
+
+    const startTime = Date.now();
+    let timedOut = false;
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn(command, args, {
+        cwd,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      this.currentProcess = proc;
+
+      let stdout = '';
+      let stderr = '';
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      // Handle stdin if provided
+      if (options?.stdin) {
+        proc.stdin?.write(options.stdin);
+        proc.stdin?.end();
+      } else {
+        proc.stdin?.end();
+      }
+
+      // Set up timeout
+      const timeoutId = setTimeout(() => {
+        timedOut = true;
+        proc.kill('SIGKILL');
+      }, timeout);
+
+      proc.on('close', (code) => {
+        clearTimeout(timeoutId);
+        this.currentProcess = null;
+
+        resolve({
+          exitCode: code ?? -1,
+          stdout,
+          stderr,
+          timedOut,
+          durationMs: Date.now() - startTime,
+        });
+      });
+
+      proc.on('error', (err) => {
+        clearTimeout(timeoutId);
+        this.currentProcess = null;
+        reject(err);
+      });
+    });
+  }
+
+  async writeFile(filePath: string, content: string): Promise<void> {
+    if (this.status !== 'running') {
+      throw new Error(`Sandbox is not running (status: ${this.status})`);
+    }
+
+    const fullPath = validatePath(this.workspacePath, filePath);
+
+    // Ensure parent directory exists
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, content, 'utf-8');
+  }
+
+  async readFile(filePath: string): Promise<string> {
+    if (this.status !== 'running') {
+      throw new Error(`Sandbox is not running (status: ${this.status})`);
+    }
+
+    const fullPath = validatePath(this.workspacePath, filePath);
+    return fs.readFile(fullPath, 'utf-8');
+  }
+
+  async listFiles(dirPath: string): Promise<string[]> {
+    if (this.status !== 'running') {
+      throw new Error(`Sandbox is not running (status: ${this.status})`);
+    }
+
+    const fullPath = validatePath(this.workspacePath, dirPath);
+    return fs.readdir(fullPath);
+  }
+
+  destroy(): Promise<void> {
+    if (this.status === 'destroyed') {
+      return Promise.resolve();
+    }
+
+    // Kill any running process
+    if (this.currentProcess) {
+      this.currentProcess.kill('SIGKILL');
+      this.currentProcess = null;
+    }
+
+    this.status = 'destroyed';
+    this.onDestroy(this.id);
+    return Promise.resolve();
+  }
+
+  getStats(): Promise<SandboxStats> {
+    // Subprocess provider doesn't track detailed stats
+    // Return empty stats object
+    return Promise.resolve({});
+  }
+}
+
+/**
+ * Subprocess-based sandbox provider.
+ *
+ * Creates sandboxes that execute commands directly on the host.
+ * Always available (Node.js is always present).
+ */
+export class SubprocessProvider extends BaseSandboxProvider {
+  readonly name = 'subprocess';
+
+  protected getProviderName(): string {
+    return 'subprocess';
+  }
+
+  isAvailable(): Promise<boolean> {
+    // Subprocess provider is always available (Node.js is always present)
+    return Promise.resolve(true);
+  }
+
+  async createSandbox(config: SandboxConfig): Promise<Sandbox> {
+    const appliedConfig = this.applyDefaults(config);
+
+    // Verify workspace path exists
+    try {
+      await fs.access(appliedConfig.workspacePath);
+    } catch {
+      throw new Error(
+        `Workspace path does not exist: ${appliedConfig.workspacePath}`
+      );
+    }
+
+    const id = generateSandboxId();
+    const defaultTimeout = appliedConfig.resourceLimits?.timeoutSeconds ?? 300;
+
+    const sandbox = new SubprocessSandbox(
+      id,
+      appliedConfig.workspacePath,
+      appliedConfig.env ?? {},
+      defaultTimeout,
+      (sandboxId) => this.unregisterSandbox(sandboxId)
+    );
+
+    this.registerSandbox(sandbox);
+    this.logger.info(
+      { sandboxId: id, workspacePath: appliedConfig.workspacePath },
+      'Created subprocess sandbox'
+    );
+
+    return sandbox;
+  }
+}

--- a/packages/server/src/sandbox/types.ts
+++ b/packages/server/src/sandbox/types.ts
@@ -1,0 +1,188 @@
+/**
+ * Sandbox Types
+ *
+ * Defines abstract interfaces for sandbox providers, enabling pluggable
+ * isolation backends for agent execution.
+ */
+
+/**
+ * Network access mode for sandbox containers.
+ */
+export type NetworkMode = 'none' | 'bridge' | 'host';
+
+/**
+ * Resource constraints for sandbox execution.
+ */
+export interface ResourceLimits {
+  /** Number of CPU cores available */
+  cpuCount?: number;
+  /** Memory limit in megabytes */
+  memoryMB?: number;
+  /** Disk space limit in megabytes (optional) */
+  diskMB?: number;
+  /** Maximum execution time in seconds */
+  timeoutSeconds?: number;
+}
+
+/**
+ * Configuration for creating a sandbox.
+ */
+export interface SandboxConfig {
+  /** Host path to workspace directory */
+  workspacePath: string;
+  /** Path inside container (default: /workspace) */
+  workspaceMount?: string;
+  /** Container image to use */
+  image?: string;
+  /** CPU, memory, disk, timeout limits */
+  resourceLimits?: ResourceLimits;
+  /** Network access mode */
+  networkMode?: NetworkMode;
+  /** Environment variables to pass */
+  env?: Record<string, string>;
+  /** User to run as inside container */
+  user?: string;
+}
+
+/**
+ * Lifecycle states for a sandbox.
+ */
+export type SandboxStatus =
+  | 'creating'
+  | 'running'
+  | 'stopped'
+  | 'destroyed'
+  | 'error';
+
+/**
+ * Options for executing a command in a sandbox.
+ */
+export interface ExecOptions {
+  /** Additional environment variables */
+  env?: Record<string, string>;
+  /** Working directory inside sandbox */
+  cwd?: string;
+  /** Command-specific timeout in seconds */
+  timeout?: number;
+  /** Input to provide to stdin */
+  stdin?: string;
+}
+
+/**
+ * Result of executing a command in a sandbox.
+ */
+export interface ExecResult {
+  /** Process exit code */
+  exitCode: number;
+  /** Standard output */
+  stdout: string;
+  /** Standard error */
+  stderr: string;
+  /** Whether execution timed out */
+  timedOut: boolean;
+  /** Execution duration in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Resource usage statistics for a sandbox.
+ */
+export interface SandboxStats {
+  /** CPU usage percentage (0-100) */
+  cpuPercent?: number;
+  /** Memory usage in bytes */
+  memoryBytes?: number;
+  /** Disk I/O read bytes */
+  diskReadBytes?: number;
+  /** Disk I/O write bytes */
+  diskWriteBytes?: number;
+  /** Network received bytes */
+  networkRxBytes?: number;
+  /** Network transmitted bytes */
+  networkTxBytes?: number;
+}
+
+/**
+ * Represents an active sandbox instance.
+ */
+export interface Sandbox {
+  /** Unique identifier for this sandbox */
+  readonly id: string;
+  /** Current lifecycle status */
+  status: SandboxStatus;
+  /** Container ID (if applicable) */
+  containerId?: string;
+
+  /**
+   * Execute a command inside the sandbox.
+   * @param command - Command to execute
+   * @param args - Command arguments
+   * @param options - Execution options
+   * @returns Execution result
+   */
+  execute(
+    command: string,
+    args: string[],
+    options?: ExecOptions
+  ): Promise<ExecResult>;
+
+  /**
+   * Write a file to the sandbox filesystem.
+   * @param path - Path relative to workspace
+   * @param content - File content
+   */
+  writeFile(path: string, content: string): Promise<void>;
+
+  /**
+   * Read a file from the sandbox filesystem.
+   * @param path - Path relative to workspace
+   * @returns File content
+   */
+  readFile(path: string): Promise<string>;
+
+  /**
+   * List files in a directory.
+   * @param path - Path relative to workspace
+   * @returns Array of file/directory names
+   */
+  listFiles(path: string): Promise<string[]>;
+
+  /**
+   * Destroy the sandbox and clean up resources.
+   */
+  destroy(): Promise<void>;
+
+  /**
+   * Get current resource usage statistics.
+   */
+  getStats(): Promise<SandboxStats>;
+}
+
+/**
+ * Provider interface for creating and managing sandboxes.
+ */
+export interface SandboxProvider {
+  /** Provider identifier (e.g., 'docker', 'subprocess') */
+  readonly name: string;
+
+  /**
+   * Check if this provider is available on the current system.
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Create a new sandbox with the given configuration.
+   * @param config - Sandbox configuration
+   */
+  createSandbox(config: SandboxConfig): Promise<Sandbox>;
+
+  /**
+   * List all active sandboxes managed by this provider.
+   */
+  listSandboxes(): Promise<Sandbox[]>;
+
+  /**
+   * Clean up orphaned resources.
+   */
+  cleanup(): Promise<void>;
+}

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -175,3 +175,16 @@ export {
   type TreeNode,
   type TreeMetadata,
 } from './tree-metadata.js';
+
+// Sandbox Types
+export type {
+  NetworkMode,
+  ResourceLimits,
+  SandboxConfig,
+  SandboxStatus,
+  ExecOptions,
+  ExecResult,
+  SandboxStats,
+  Sandbox,
+  SandboxProvider,
+} from '../sandbox/types.js';

--- a/packages/server/test/sandbox/subprocess-provider.test.ts
+++ b/packages/server/test/sandbox/subprocess-provider.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Subprocess Provider Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { SubprocessProvider } from '../../src/sandbox/subprocess-provider.js';
+import type { Sandbox } from '../../src/sandbox/types.js';
+
+describe('SubprocessProvider', () => {
+  let provider: SubprocessProvider;
+  let tempDir: string;
+  let sandbox: Sandbox | null = null;
+
+  beforeEach(async () => {
+    provider = new SubprocessProvider();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sandbox-test-'));
+  });
+
+  afterEach(async () => {
+    // Destroy sandbox if created
+    if (sandbox) {
+      await sandbox.destroy();
+      sandbox = null;
+    }
+
+    // Cleanup provider
+    await provider.cleanup();
+
+    // Remove temp directory
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('provider basics', () => {
+    it('should have name "subprocess"', () => {
+      expect(provider.name).toBe('subprocess');
+    });
+
+    it('should always be available', async () => {
+      const available = await provider.isAvailable();
+      expect(available).toBe(true);
+    });
+
+    it('should list sandboxes', async () => {
+      const sandboxes = await provider.listSandboxes();
+      expect(sandboxes).toEqual([]);
+    });
+  });
+
+  describe('createSandbox', () => {
+    it('should create sandbox with valid workspace path', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      expect(sandbox).toBeDefined();
+      expect(sandbox.id).toMatch(/^subprocess-/);
+      expect(sandbox.status).toBe('running');
+    });
+
+    it('should throw if workspace path does not exist', async () => {
+      await expect(
+        provider.createSandbox({
+          workspacePath: '/nonexistent/path',
+        })
+      ).rejects.toThrow('Workspace path does not exist');
+    });
+
+    it('should register sandbox in provider', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      const sandboxes = await provider.listSandboxes();
+      expect(sandboxes).toHaveLength(1);
+      expect(sandboxes[0]?.id).toBe(sandbox.id);
+    });
+  });
+
+  describe('execute', () => {
+    beforeEach(async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+    });
+
+    it('should execute simple command', async () => {
+      const result = await sandbox!.execute('echo', ['hello world']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('hello world');
+      expect(result.stderr).toBe('');
+      expect(result.timedOut).toBe(false);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should capture stderr', async () => {
+      const result = await sandbox!.execute('sh', [
+        '-c',
+        'echo error >&2; exit 1',
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.trim()).toBe('error');
+    });
+
+    it('should handle node execution', async () => {
+      const result = await sandbox!.execute('node', [
+        '-e',
+        'console.log("test output")',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('test output');
+    });
+
+    it('should use workspace as cwd', async () => {
+      const result = await sandbox!.execute('pwd', []);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(tempDir);
+    });
+
+    it('should use custom cwd within workspace', async () => {
+      const subdir = 'subdir';
+      await fs.mkdir(path.join(tempDir, subdir));
+
+      const result = await sandbox!.execute('pwd', [], {
+        cwd: subdir,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(path.join(tempDir, subdir));
+    });
+
+    it('should pass environment variables', async () => {
+      const result = await sandbox!.execute('sh', ['-c', 'echo $TEST_VAR'], {
+        env: { TEST_VAR: 'test_value' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('test_value');
+    });
+
+    it('should handle timeout', async () => {
+      const result = await sandbox!.execute('sleep', ['10'], {
+        timeout: 1, // 1 second timeout
+      });
+
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it('should handle stdin', async () => {
+      const result = await sandbox!.execute('cat', [], {
+        stdin: 'input text',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('input text');
+    });
+
+    it('should throw if sandbox is destroyed', async () => {
+      await sandbox!.destroy();
+
+      await expect(sandbox!.execute('echo', ['test'])).rejects.toThrow(
+        'Sandbox is not running'
+      );
+    });
+  });
+
+  describe('file operations', () => {
+    beforeEach(async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+    });
+
+    it('should write and read file', async () => {
+      await sandbox!.writeFile('test.txt', 'file content');
+      const content = await sandbox!.readFile('test.txt');
+
+      expect(content).toBe('file content');
+    });
+
+    it('should create nested directories for writeFile', async () => {
+      await sandbox!.writeFile('nested/deep/file.txt', 'nested content');
+      const content = await sandbox!.readFile('nested/deep/file.txt');
+
+      expect(content).toBe('nested content');
+    });
+
+    it('should list files in directory', async () => {
+      await sandbox!.writeFile('file1.txt', 'content1');
+      await sandbox!.writeFile('file2.txt', 'content2');
+
+      const files = await sandbox!.listFiles('.');
+
+      expect(files).toContain('file1.txt');
+      expect(files).toContain('file2.txt');
+    });
+
+    it('should block path traversal in writeFile', async () => {
+      await expect(
+        sandbox!.writeFile('../escape.txt', 'malicious')
+      ).rejects.toThrow('Path traversal detected');
+    });
+
+    it('should block path traversal in readFile', async () => {
+      await expect(sandbox!.readFile('../../../etc/passwd')).rejects.toThrow(
+        'Path traversal detected'
+      );
+    });
+
+    it('should block path traversal in listFiles', async () => {
+      await expect(sandbox!.listFiles('../..')).rejects.toThrow(
+        'Path traversal detected'
+      );
+    });
+
+    it('should throw if sandbox is destroyed', async () => {
+      await sandbox!.destroy();
+
+      await expect(sandbox!.writeFile('test.txt', 'content')).rejects.toThrow(
+        'Sandbox is not running'
+      );
+
+      await expect(sandbox!.readFile('test.txt')).rejects.toThrow(
+        'Sandbox is not running'
+      );
+
+      await expect(sandbox!.listFiles('.')).rejects.toThrow(
+        'Sandbox is not running'
+      );
+    });
+  });
+
+  describe('destroy', () => {
+    it('should set status to destroyed', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      expect(sandbox.status).toBe('running');
+
+      await sandbox.destroy();
+
+      expect(sandbox.status).toBe('destroyed');
+    });
+
+    it('should unregister from provider', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      const sandboxId = sandbox.id;
+      await sandbox.destroy();
+      sandbox = null; // Don't double-destroy in afterEach
+
+      const sandboxes = await provider.listSandboxes();
+      expect(sandboxes.find((s) => s.id === sandboxId)).toBeUndefined();
+    });
+
+    it('should be idempotent', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      await sandbox.destroy();
+      await sandbox.destroy(); // Should not throw
+      sandbox = null;
+
+      expect(true).toBe(true); // If we get here, no error
+    });
+
+    it('should kill running processes', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      // Start a long-running process (don't await)
+      const execPromise = sandbox.execute('sleep', ['60']);
+
+      // Destroy immediately
+      await sandbox.destroy();
+      sandbox = null;
+
+      // The exec should complete (possibly with error) after destroy
+      const result = await execPromise;
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return empty stats', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      const stats = await sandbox.getStats();
+
+      expect(stats).toEqual({});
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should destroy all sandboxes', async () => {
+      const sandbox1 = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+      const sandbox2 = await provider.createSandbox({
+        workspacePath: tempDir,
+      });
+
+      expect(await provider.listSandboxes()).toHaveLength(2);
+
+      await provider.cleanup();
+
+      expect(await provider.listSandboxes()).toHaveLength(0);
+      expect(sandbox1.status).toBe('destroyed');
+      expect(sandbox2.status).toBe('destroyed');
+    });
+  });
+
+  describe('config options', () => {
+    it('should use env from config', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+        env: { CONFIG_VAR: 'from_config' },
+      });
+
+      const result = await sandbox.execute('sh', ['-c', 'echo $CONFIG_VAR']);
+
+      expect(result.stdout.trim()).toBe('from_config');
+    });
+
+    it('should use resourceLimits.timeoutSeconds as default timeout', async () => {
+      sandbox = await provider.createSandbox({
+        workspacePath: tempDir,
+        resourceLimits: {
+          timeoutSeconds: 1,
+        },
+      });
+
+      // This will use the default 1 second timeout
+      const result = await sandbox.execute('sleep', ['10']);
+
+      expect(result.timedOut).toBe(true);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.0.218
         version: 1.0.218
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.16
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
@@ -157,6 +160,9 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@types/adm-zip':
+        specifier: ^0.5.7
+        version: 0.5.7
       '@types/node':
         specifier: ^20.10.6
         version: 20.19.27
@@ -1023,6 +1029,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@types/adm-zip@0.5.7':
+    resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1308,6 +1317,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3734,6 +3747,10 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@types/adm-zip@0.5.7':
+    dependencies:
+      '@types/node': 20.19.27
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -4151,6 +4168,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.16: {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
## Summary
- Implement pluggable sandbox provider pattern for container isolation (Thrust 1)
- Add SubprocessProvider as fallback for development/non-Docker environments (Thrust 2)
- Add comprehensive unit tests for subprocess provider (30 tests)

## Changes

### Thrust 1: Sandbox Provider Interface
- `packages/server/src/sandbox/types.ts` - Core types: SandboxConfig, ResourceLimits, ExecOptions, ExecResult, Sandbox, SandboxProvider interfaces
- `packages/server/src/sandbox/provider.ts` - BaseSandboxProvider abstract class with common functionality
- `packages/server/src/sandbox/index.ts` - Module exports
- `packages/server/src/types/index.ts` - Re-export sandbox types

### Thrust 2: Subprocess Provider  
- `packages/server/src/sandbox/subprocess-provider.ts` - SubprocessProvider and SubprocessSandbox classes
  - Execute commands via child_process.spawn
  - File read/write with path traversal protection
  - Process tracking and cleanup

### Tests
- `packages/server/test/sandbox/subprocess-provider.test.ts` - 30 unit tests covering:
  - Provider availability and sandbox creation
  - Command execution (stdout, stderr, exit codes, timeouts)
  - File operations with path traversal protection
  - Sandbox lifecycle management

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes  
- [x] `pnpm test test/sandbox/subprocess-provider.test.ts` - 30/30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)