### PR TITLE
feat: add Claude Agent SDK types and dependencies (v0.2.14 Thrusts 1-2)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,9 @@
   },
   "dependencies": {
     "@agentgate/shared": "workspace:*",
+    "@anthropic-ai/claude-agent-sdk": "^0.1.x",
     "@fastify/cors": "^11.2.0",
+    "adm-zip": "^0.5.16",
     "@fastify/websocket": "^11.2.0",
     "@octokit/rest": "^22.0.1",
     "@openai/codex-sdk": "^0.77.0",
@@ -45,6 +47,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.6",
     "@types/node": "^20.10.6",
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^6.17.0",

--- a/packages/server/src/types/agent.ts
+++ b/packages/server/src/types/agent.ts
@@ -1,3 +1,5 @@
+import type { ToolCallRecord } from './sdk.js';
+
 // Agent Request
 export interface AgentRequest {
   workspacePath: string;
@@ -27,6 +29,11 @@ export interface AgentResult {
   sessionId: string | null;
   tokensUsed: TokenUsage | null;
   durationMs: number;
+  // SDK-specific fields (optional, populated by claude-agent-sdk driver)
+  totalCostUsd?: number;
+  toolCalls?: ToolCallRecord[];
+  model?: string;
+  turns?: number;
 }
 
 // Agent Structured Output
@@ -69,8 +76,13 @@ export interface DriverCapabilities {
   supportsStructuredOutput: boolean;
   supportsToolRestriction: boolean;
   supportsTimeout: boolean;
-  supportsHooks?: boolean;
   maxTurns: number;
+  // SDK-specific capabilities
+  supportsHooks?: boolean;
+  supportsSandbox?: boolean;
+  supportsStreaming?: boolean;
+  supportsCostTracking?: boolean;
+  billingMethod?: 'api-key' | 'subscription';
 }
 
 // Driver Interface

--- a/packages/server/src/types/index.ts
+++ b/packages/server/src/types/index.ts
@@ -175,3 +175,30 @@ export {
   type TreeNode,
   type TreeMetadata,
 } from './tree-metadata.js';
+
+// SDK Types (Claude Agent SDK integration)
+export {
+  type SDKMessage,
+  type SDKSystemMessage,
+  type SDKAssistantMessage,
+  type SDKUserMessage,
+  type SDKToolUseMessage,
+  type SDKToolResultMessage,
+  type SDKResultMessage,
+  type SDKToolCall,
+  type SDKHookMatcher,
+  type SDKQueryOptions,
+  type SDKQueryResult,
+  type PreToolValidator,
+  type PostToolHandler,
+  type SDKHooksConfig,
+  type ClaudeAgentSDKDriverConfig,
+  type ToolCallRecord,
+  type SDKExecutionResult,
+  isSDKSystemMessage,
+  isSDKAssistantMessage,
+  isSDKUserMessage,
+  isSDKToolUseMessage,
+  isSDKToolResultMessage,
+  isSDKResultMessage,
+} from './sdk.js';

--- a/packages/server/src/types/sdk.ts
+++ b/packages/server/src/types/sdk.ts
@@ -1,0 +1,285 @@
+/**
+ * Claude Agent SDK Types
+ *
+ * These types define the interface for the Claude Agent SDK integration.
+ * They bridge SDK types to AgentGate types and provide type safety for
+ * SDK-based agent execution.
+ *
+ * Note: Once @anthropic-ai/claude-agent-sdk is published, these types
+ * should be updated to re-export from the SDK package directly.
+ */
+
+// ============================================================================
+// SDK Message Types
+// ============================================================================
+
+/**
+ * Base message interface with common fields
+ */
+interface SDKMessageBase {
+  timestamp?: string;
+}
+
+/**
+ * System message - contains session info and configuration
+ */
+export interface SDKSystemMessage extends SDKMessageBase {
+  type: 'system';
+  session_id: string;
+  tools: string[];
+  model: string;
+}
+
+/**
+ * Assistant message - Claude's response
+ */
+export interface SDKAssistantMessage extends SDKMessageBase {
+  type: 'assistant';
+  content: string;
+  tool_use?: SDKToolCall[];
+}
+
+/**
+ * User message - user prompt
+ */
+export interface SDKUserMessage extends SDKMessageBase {
+  type: 'user';
+  content: string;
+}
+
+/**
+ * Tool use message - tool invocation
+ */
+export interface SDKToolUseMessage extends SDKMessageBase {
+  type: 'tool_use';
+  tool: string;
+  input: unknown;
+  id: string;
+}
+
+/**
+ * Tool result message - tool execution result
+ */
+export interface SDKToolResultMessage extends SDKMessageBase {
+  type: 'tool_result';
+  tool: string;
+  output: unknown;
+  id: string;
+  is_error?: boolean;
+}
+
+/**
+ * Result message - final execution result
+ */
+export interface SDKResultMessage extends SDKMessageBase {
+  type: 'result';
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+  cost: number;
+  result: 'success' | 'error' | 'interrupted';
+  session_id: string;
+}
+
+/**
+ * Union of all SDK message types
+ */
+export type SDKMessage =
+  | SDKSystemMessage
+  | SDKAssistantMessage
+  | SDKUserMessage
+  | SDKToolUseMessage
+  | SDKToolResultMessage
+  | SDKResultMessage;
+
+/**
+ * Tool call within an assistant message
+ */
+export interface SDKToolCall {
+  id: string;
+  tool: string;
+  input: unknown;
+}
+
+// ============================================================================
+// SDK Options & Configuration
+// ============================================================================
+
+/**
+ * Hook matcher for PreToolUse/PostToolUse hooks
+ */
+export interface SDKHookMatcher {
+  tool?: string;
+  tools?: string[];
+  pattern?: string;
+}
+
+/**
+ * SDK query options
+ */
+export interface SDKQueryOptions {
+  /** Tools to allow (whitelist) */
+  allowedTools?: string[];
+  /** Tools to disallow (blacklist) */
+  disallowedTools?: string[];
+  /** Maximum conversation turns */
+  maxTurns?: number;
+  /** Model to use */
+  model?: string;
+  /** Custom system prompt */
+  systemPrompt?: string;
+  /** Session ID to resume */
+  resume?: string;
+  /** Working directory */
+  cwd?: string;
+  /** Timeout in milliseconds */
+  timeoutMs?: number;
+  /** Hook configuration */
+  hooks?: {
+    PreToolUse?: SDKHookMatcher[];
+    PostToolUse?: SDKHookMatcher[];
+  };
+}
+
+/**
+ * SDK query result
+ */
+export interface SDKQueryResult {
+  /** All messages from the session */
+  messages: SDKMessage[];
+  /** Session ID for resume */
+  sessionId: string;
+  /** Token usage */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+  /** Total cost in USD */
+  costUsd: number;
+  /** Result status */
+  result: 'success' | 'error' | 'interrupted';
+}
+
+// ============================================================================
+// AgentGate SDK Driver Types
+// ============================================================================
+
+/**
+ * PreToolUse validator function
+ */
+export type PreToolValidator = (
+  tool: string,
+  input: unknown
+) => Promise<{ allow: boolean; reason?: string }>;
+
+/**
+ * PostToolUse handler function
+ */
+export type PostToolHandler = (
+  tool: string,
+  input: unknown,
+  output: unknown,
+  durationMs: number
+) => Promise<void>;
+
+/**
+ * Hooks configuration for SDK driver
+ */
+export interface SDKHooksConfig {
+  /** Enable tool logging hook */
+  logToolUse?: boolean;
+  /** Enable file change tracking hook */
+  trackFileChanges?: boolean;
+  /** Custom PreToolUse validators */
+  preToolValidators?: PreToolValidator[];
+  /** Custom PostToolUse handlers */
+  postToolHandlers?: PostToolHandler[];
+}
+
+/**
+ * SDK driver configuration
+ */
+export interface ClaudeAgentSDKDriverConfig {
+  /** Timeout for queries in ms (default: 300000) */
+  timeoutMs?: number;
+  /** Enable SDK sandboxing (default: true) */
+  enableSandbox?: boolean;
+  /** Custom hooks configuration */
+  hooks?: SDKHooksConfig;
+  /** Additional environment variables */
+  env?: Record<string, string>;
+}
+
+/**
+ * Tool call record from SDK execution
+ */
+export interface ToolCallRecord {
+  tool: string;
+  input: unknown;
+  output: unknown;
+  durationMs: number;
+  timestamp: Date;
+}
+
+/**
+ * SDK-specific execution result
+ */
+export interface SDKExecutionResult {
+  sessionId: string;
+  model: string;
+  turns: number;
+  totalCostUsd: number;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+  toolCalls: ToolCallRecord[];
+  messages: SDKMessage[];
+}
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+/**
+ * Type guard for SDKSystemMessage
+ */
+export function isSDKSystemMessage(msg: SDKMessage): msg is SDKSystemMessage {
+  return msg.type === 'system';
+}
+
+/**
+ * Type guard for SDKAssistantMessage
+ */
+export function isSDKAssistantMessage(msg: SDKMessage): msg is SDKAssistantMessage {
+  return msg.type === 'assistant';
+}
+
+/**
+ * Type guard for SDKUserMessage
+ */
+export function isSDKUserMessage(msg: SDKMessage): msg is SDKUserMessage {
+  return msg.type === 'user';
+}
+
+/**
+ * Type guard for SDKToolUseMessage
+ */
+export function isSDKToolUseMessage(msg: SDKMessage): msg is SDKToolUseMessage {
+  return msg.type === 'tool_use';
+}
+
+/**
+ * Type guard for SDKToolResultMessage
+ */
+export function isSDKToolResultMessage(msg: SDKMessage): msg is SDKToolResultMessage {
+  return msg.type === 'tool_result';
+}
+
+/**
+ * Type guard for SDKResultMessage
+ */
+export function isSDKResultMessage(msg: SDKMessage): msg is SDKResultMessage {
+  return msg.type === 'result';
+}

--- a/packages/server/src/types/work-order.ts
+++ b/packages/server/src/types/work-order.ts
@@ -27,6 +27,7 @@ export type IntegrationStatus = (typeof IntegrationStatus)[keyof typeof Integrat
 export const AgentType = {
   CLAUDE_CODE_API: 'claude-code-api',
   CLAUDE_CODE_SUBSCRIPTION: 'claude-code-subscription',
+  CLAUDE_AGENT_SDK: 'claude-agent-sdk',
 } as const;
 
 export type AgentType = (typeof AgentType)[keyof typeof AgentType];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@agentgate/shared':
         specifier: workspace:*
         version: link:../shared
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.1.x
+        version: 0.1.76(zod@3.25.76)
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
@@ -120,6 +123,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.0.218
         version: 1.0.218
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.16
       ajv:
         specifier: ^8.12.0
         version: 8.17.1
@@ -157,6 +163,9 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@types/adm-zip':
+        specifier: ^0.5.6
+        version: 0.5.7
       '@types/node':
         specifier: ^20.10.6
         version: 20.19.27
@@ -222,6 +231,12 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@anthropic-ai/claude-agent-sdk@0.1.76':
+    resolution: {integrity: sha512-s7RvpXoFaLXLG7A1cJBAPD8ilwOhhc/12fb5mJXRuD561o4FmPtQ+WRfuy9akMmrFRfLsKv8Ornw3ClGAPL2fw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.1 || ^4.0.0
 
   '@asamuzakjp/css-color@4.1.1':
     resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
@@ -752,6 +767,89 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1022,6 +1120,9 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@types/adm-zip@0.5.7':
+    resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1308,6 +1409,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3064,6 +3169,19 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@anthropic-ai/claude-agent-sdk@0.1.76(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   '@asamuzakjp/css-color@4.1.1':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -3494,6 +3612,65 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3733,6 +3910,10 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@types/adm-zip@0.5.7':
+    dependencies:
+      '@types/node': 20.19.27
 
   '@types/aria-query@5.0.4': {}
 
@@ -4151,6 +4332,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.16: {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
## Summary

- **Thrust 1: SDK Dependencies** - Added `@anthropic-ai/claude-agent-sdk` to packages/server dependencies, along with `adm-zip` and `@types/adm-zip` to fix a pre-existing type issue
- **Thrust 2: SDK Types** - Created comprehensive TypeScript types for SDK integration including SDKMessage types, query options, hooks configuration, and driver config types
- Extended `AgentResult` with SDK-specific fields (cost tracking, tool calls, model info) and `DriverCapabilities` with SDK capability flags

## Changes

### New Files
- `packages/server/src/types/sdk.ts` - Complete SDK type definitions with type guards

### Modified Files  
- `packages/server/package.json` - Added SDK and adm-zip dependencies
- `packages/server/src/types/agent.ts` - Extended AgentResult and DriverCapabilities
- `packages/server/src/types/work-order.ts` - Added 'claude-agent-sdk' to AgentType
- `packages/server/src/types/index.ts` - Exported all SDK types

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (1 pre-existing warning unrelated to changes)
- [x] `pnpm test` - 577 tests pass (1 pre-existing contract test failure unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)