### PR TITLE
feat: implement dashboard live view (v0.2.11 Thrusts 5-6)

### DIFF
--- a/packages/dashboard/src/api/__tests__/websocket.test.ts
+++ b/packages/dashboard/src/api/__tests__/websocket.test.ts
@@ -269,8 +269,8 @@ describe('WebSocketClient', () => {
       client.subscribe(handler);
 
       MockWebSocket.instances[0].simulateMessage({
-        type: 'workorder:updated',
-        // Missing 'data' field - intentionally invalid for testing
+        // Missing 'type' field - intentionally invalid for testing
+        data: { id: 'test' },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);
 

--- a/packages/dashboard/src/components/streaming/AgentActivityPanel.tsx
+++ b/packages/dashboard/src/components/streaming/AgentActivityPanel.tsx
@@ -1,0 +1,242 @@
+/**
+ * AgentActivityPanel - Real-time display of agent activity
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Wifi, WifiOff, RefreshCw, Pause, Play, ArrowDown } from 'lucide-react';
+import { EventCard } from './EventCard';
+import { useRunStream } from '../../hooks/useRunStream';
+import type { ConnectionState } from '../../api/websocket';
+
+export interface AgentActivityPanelProps {
+  workOrderId: string;
+  maxEvents?: number;
+  autoScroll?: boolean;
+  className?: string;
+}
+
+interface ConnectionStatusIndicatorProps {
+  connectionState: ConnectionState;
+  isSubscribed: boolean;
+  onReconnect: () => void;
+}
+
+function ConnectionStatusIndicator({
+  connectionState,
+  isSubscribed,
+  onReconnect,
+}: ConnectionStatusIndicatorProps) {
+  const getStatusConfig = () => {
+    if (connectionState === 'connected' && isSubscribed) {
+      return {
+        icon: <Wifi className="w-3.5 h-3.5" />,
+        color: 'text-green-600',
+        bgColor: 'bg-green-50',
+        borderColor: 'border-green-200',
+        label: 'Live',
+        pulse: true,
+      };
+    }
+    if (connectionState === 'connecting') {
+      return {
+        icon: <RefreshCw className="w-3.5 h-3.5 animate-spin" />,
+        color: 'text-yellow-600',
+        bgColor: 'bg-yellow-50',
+        borderColor: 'border-yellow-200',
+        label: 'Connecting...',
+        pulse: false,
+      };
+    }
+    if (connectionState === 'error') {
+      return {
+        icon: <WifiOff className="w-3.5 h-3.5" />,
+        color: 'text-red-600',
+        bgColor: 'bg-red-50',
+        borderColor: 'border-red-200',
+        label: 'Error',
+        pulse: false,
+      };
+    }
+    return {
+      icon: <WifiOff className="w-3.5 h-3.5" />,
+      color: 'text-gray-600',
+      bgColor: 'bg-gray-50',
+      borderColor: 'border-gray-200',
+      label: 'Disconnected',
+      pulse: false,
+    };
+  };
+
+  const config = getStatusConfig();
+  const showReconnect = connectionState === 'disconnected' || connectionState === 'error';
+
+  return (
+    <button
+      onClick={showReconnect ? onReconnect : undefined}
+      disabled={!showReconnect}
+      className={`
+        flex items-center gap-1.5 px-2 py-1 rounded-md border text-xs font-medium
+        ${config.bgColor} ${config.borderColor} ${config.color}
+        ${showReconnect ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}
+        transition-all
+      `}
+      title={showReconnect ? 'Click to reconnect' : undefined}
+    >
+      {config.icon}
+      <span>{config.label}</span>
+      {config.pulse && <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />}
+    </button>
+  );
+}
+
+export function AgentActivityPanel({
+  workOrderId,
+  maxEvents = 500,
+  autoScroll: initialAutoScroll = true,
+  className = '',
+}: AgentActivityPanelProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [autoScroll, setAutoScroll] = useState(initialAutoScroll);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const lastScrollTopRef = useRef(0);
+
+  const {
+    events,
+    isSubscribed,
+    connectionState,
+    subscribe,
+    clearEvents,
+  } = useRunStream({ maxEvents });
+
+  // Subscribe to work order on mount
+  useEffect(() => {
+    if (workOrderId) {
+      subscribe(workOrderId);
+    }
+  }, [workOrderId, subscribe]);
+
+  // Auto-scroll to bottom when new events arrive
+  useEffect(() => {
+    if (autoScroll && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = scrollContainerRef.current.scrollHeight;
+    }
+  }, [events, autoScroll]);
+
+  // Handle scroll events to detect manual scrolling
+  const handleScroll = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
+
+    // User scrolled up - disable auto-scroll
+    if (scrollTop < lastScrollTopRef.current && !isAtBottom) {
+      setAutoScroll(false);
+      setShowScrollToBottom(true);
+    }
+
+    // User scrolled to bottom - enable auto-scroll
+    if (isAtBottom) {
+      setAutoScroll(true);
+      setShowScrollToBottom(false);
+    }
+
+    lastScrollTopRef.current = scrollTop;
+  }, []);
+
+  // Scroll to bottom manually
+  const scrollToBottom = useCallback(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = scrollContainerRef.current.scrollHeight;
+      setAutoScroll(true);
+      setShowScrollToBottom(false);
+    }
+  }, []);
+
+  // Toggle auto-scroll
+  const toggleAutoScroll = useCallback(() => {
+    setAutoScroll((prev) => !prev);
+    if (!autoScroll && scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = scrollContainerRef.current.scrollHeight;
+    }
+  }, [autoScroll]);
+
+  // Reconnect handler
+  const handleReconnect = useCallback(() => {
+    subscribe(workOrderId);
+  }, [subscribe, workOrderId]);
+
+  return (
+    <div className={`flex flex-col bg-white rounded-lg border border-gray-200 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+        <div className="flex items-center gap-3">
+          <h3 className="text-sm font-semibold text-gray-900">Live Activity</h3>
+          <ConnectionStatusIndicator
+            connectionState={connectionState}
+            isSubscribed={isSubscribed}
+            onReconnect={handleReconnect}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-500">{events.length} events</span>
+          <button
+            onClick={toggleAutoScroll}
+            className={`
+              p-1.5 rounded border transition-colors
+              ${autoScroll
+                ? 'bg-blue-50 border-blue-200 text-blue-600'
+                : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+              }
+            `}
+            title={autoScroll ? 'Auto-scroll enabled' : 'Auto-scroll disabled'}
+          >
+            {autoScroll ? <Play className="w-3.5 h-3.5" /> : <Pause className="w-3.5 h-3.5" />}
+          </button>
+          <button
+            onClick={clearEvents}
+            className="px-2 py-1 text-xs text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      {/* Events list */}
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto p-4 space-y-2 min-h-[200px] max-h-[600px]"
+      >
+        {events.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-500">
+            <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mb-3">
+              <Wifi className="w-6 h-6 text-gray-400" />
+            </div>
+            <p className="text-sm font-medium">Waiting for activity...</p>
+            <p className="text-xs mt-1">Events will appear here as the agent works</p>
+          </div>
+        ) : (
+          events.map((event, index) => (
+            <EventCard
+              key={`${event.timestamp}-${index}`}
+              event={event}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Scroll to bottom button */}
+      {showScrollToBottom && (
+        <button
+          onClick={scrollToBottom}
+          className="absolute bottom-4 right-4 p-2 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 transition-colors"
+          title="Scroll to bottom"
+        >
+          <ArrowDown className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/streaming/ErrorsTab.tsx
+++ b/packages/dashboard/src/components/streaming/ErrorsTab.tsx
@@ -1,0 +1,136 @@
+/**
+ * ErrorsTab - Display errors and warnings
+ */
+
+import { useState, memo } from 'react';
+import { AlertCircle, ChevronDown, ChevronRight, Copy, Check, AlertTriangle } from 'lucide-react';
+import type { AgentErrorEvent } from '../../types/agent-events';
+
+export interface ErrorsTabProps {
+  errors: AgentErrorEvent[];
+  className?: string;
+}
+
+interface ErrorItemProps {
+  error: AgentErrorEvent;
+}
+
+function formatTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+function ErrorItemComponent({ error }: ErrorItemProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const hasDetails = error.details && Object.keys(error.details).length > 0;
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const text = hasDetails
+      ? `${error.message}\n\nDetails:\n${JSON.stringify(error.details, null, 2)}`
+      : error.message;
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 overflow-hidden">
+      {/* Header */}
+      <div
+        className={`flex items-start gap-3 p-3 ${hasDetails ? 'cursor-pointer hover:bg-red-100' : ''}`}
+        onClick={() => hasDetails && setIsExpanded(!isExpanded)}
+      >
+        {/* Expand chevron */}
+        <div className="flex-shrink-0 w-4 h-4 mt-0.5">
+          {hasDetails ? (
+            isExpanded ? (
+              <ChevronDown className="w-4 h-4 text-red-500" />
+            ) : (
+              <ChevronRight className="w-4 h-4 text-red-500" />
+            )
+          ) : null}
+        </div>
+
+        {/* Error icon */}
+        <AlertCircle className="w-4 h-4 text-red-600 flex-shrink-0 mt-0.5" />
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-red-800 break-words">{error.message}</p>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-xs text-red-600">Work Order: {error.workOrderId}</span>
+            {error.runId !== 'unknown' && (
+              <span className="text-xs text-red-600">Run: {error.runId}</span>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleCopy}
+            className="p-1 hover:bg-red-100 rounded transition-colors"
+            title="Copy error"
+          >
+            {copied ? (
+              <Check className="w-3.5 h-3.5 text-green-600" />
+            ) : (
+              <Copy className="w-3.5 h-3.5 text-red-500" />
+            )}
+          </button>
+          <span className="text-xs text-red-500">{formatTime(error.timestamp)}</span>
+        </div>
+      </div>
+
+      {/* Expanded details */}
+      {isExpanded && hasDetails && (
+        <div className="px-3 pb-3 pt-0">
+          <div className="text-xs font-medium text-red-700 mb-1">Details</div>
+          <pre className="text-xs bg-white rounded border border-red-200 p-2 overflow-x-auto max-h-40 overflow-y-auto font-mono">
+            {JSON.stringify(error.details, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const ErrorItem = memo(ErrorItemComponent);
+
+export function ErrorsTab({ errors, className = '' }: ErrorsTabProps) {
+  if (errors.length === 0) {
+    return (
+      <div className={`flex flex-col items-center justify-center py-12 text-gray-500 ${className}`}>
+        <div className="w-12 h-12 rounded-full bg-green-50 flex items-center justify-center mb-3">
+          <Check className="w-6 h-6 text-green-500" />
+        </div>
+        <p className="text-sm font-medium">No errors</p>
+        <p className="text-xs mt-1">All operations completed successfully</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col ${className}`}>
+      {/* Header */}
+      <div className="flex items-center gap-2 mb-4">
+        <AlertTriangle className="w-4 h-4 text-red-600" />
+        <span className="text-sm font-medium text-red-700">{errors.length} error(s)</span>
+      </div>
+
+      {/* Error list */}
+      <div className="flex-1 overflow-y-auto max-h-[500px] space-y-2">
+        {errors.map((error, index) => (
+          <ErrorItem key={`${error.timestamp}-${index}`} error={error} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/streaming/EventCard.tsx
+++ b/packages/dashboard/src/components/streaming/EventCard.tsx
@@ -1,0 +1,398 @@
+/**
+ * EventCard component for rendering individual agent events
+ */
+
+import { useState, memo } from 'react';
+import {
+  BookOpen,
+  FileEdit,
+  Pencil,
+  Terminal,
+  Search,
+  FolderSearch,
+  Globe,
+  MessageSquare,
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Check,
+  Play,
+  CheckCircle,
+  XCircle,
+  BarChart3,
+  FileIcon,
+} from 'lucide-react';
+import type { AgentEvent, AgentToolName } from '../../types/agent-events';
+
+export interface EventCardProps {
+  event: AgentEvent;
+  expanded?: boolean;
+  onToggle?: () => void;
+}
+
+interface EventConfig {
+  icon: React.ReactNode;
+  bgColor: string;
+  borderColor: string;
+  textColor: string;
+  label: string;
+}
+
+function getToolConfig(tool: AgentToolName): EventConfig {
+  switch (tool) {
+    case 'Read':
+      return {
+        icon: <BookOpen className="w-4 h-4" />,
+        bgColor: 'bg-blue-50',
+        borderColor: 'border-blue-200',
+        textColor: 'text-blue-700',
+        label: 'Read',
+      };
+    case 'Write':
+      return {
+        icon: <FileEdit className="w-4 h-4" />,
+        bgColor: 'bg-green-50',
+        borderColor: 'border-green-200',
+        textColor: 'text-green-700',
+        label: 'Write',
+      };
+    case 'Edit':
+      return {
+        icon: <Pencil className="w-4 h-4" />,
+        bgColor: 'bg-green-50',
+        borderColor: 'border-green-200',
+        textColor: 'text-green-700',
+        label: 'Edit',
+      };
+    case 'Bash':
+      return {
+        icon: <Terminal className="w-4 h-4" />,
+        bgColor: 'bg-yellow-50',
+        borderColor: 'border-yellow-200',
+        textColor: 'text-yellow-700',
+        label: 'Bash',
+      };
+    case 'Grep':
+      return {
+        icon: <Search className="w-4 h-4" />,
+        bgColor: 'bg-purple-50',
+        borderColor: 'border-purple-200',
+        textColor: 'text-purple-700',
+        label: 'Grep',
+      };
+    case 'Glob':
+      return {
+        icon: <FolderSearch className="w-4 h-4" />,
+        bgColor: 'bg-purple-50',
+        borderColor: 'border-purple-200',
+        textColor: 'text-purple-700',
+        label: 'Glob',
+      };
+    case 'WebFetch':
+    case 'WebSearch':
+      return {
+        icon: <Globe className="w-4 h-4" />,
+        bgColor: 'bg-cyan-50',
+        borderColor: 'border-cyan-200',
+        textColor: 'text-cyan-700',
+        label: tool,
+      };
+    default:
+      return {
+        icon: <Terminal className="w-4 h-4" />,
+        bgColor: 'bg-gray-50',
+        borderColor: 'border-gray-200',
+        textColor: 'text-gray-700',
+        label: 'Tool',
+      };
+  }
+}
+
+function getEventConfig(event: AgentEvent): EventConfig {
+  switch (event.type) {
+    case 'agent_tool_call':
+      return getToolConfig(event.tool);
+    case 'agent_tool_result': {
+      const baseConfig = {
+        icon: event.success ? (
+          <CheckCircle className="w-4 h-4" />
+        ) : (
+          <XCircle className="w-4 h-4" />
+        ),
+        bgColor: event.success ? 'bg-green-50' : 'bg-red-50',
+        borderColor: event.success ? 'border-green-200' : 'border-red-200',
+        textColor: event.success ? 'text-green-700' : 'text-red-700',
+        label: event.success ? 'Success' : 'Error',
+      };
+      return baseConfig;
+    }
+    case 'agent_output':
+      return {
+        icon: <MessageSquare className="w-4 h-4" />,
+        bgColor: 'bg-gray-50',
+        borderColor: 'border-gray-200',
+        textColor: 'text-gray-700',
+        label: 'Output',
+      };
+    case 'file_changed':
+      return {
+        icon: <FileIcon className="w-4 h-4" />,
+        bgColor:
+          event.action === 'created'
+            ? 'bg-green-50'
+            : event.action === 'deleted'
+              ? 'bg-red-50'
+              : 'bg-yellow-50',
+        borderColor:
+          event.action === 'created'
+            ? 'border-green-200'
+            : event.action === 'deleted'
+              ? 'border-red-200'
+              : 'border-yellow-200',
+        textColor:
+          event.action === 'created'
+            ? 'text-green-700'
+            : event.action === 'deleted'
+              ? 'text-red-700'
+              : 'text-yellow-700',
+        label: event.action.charAt(0).toUpperCase() + event.action.slice(1),
+      };
+    case 'progress_update':
+      return {
+        icon: <BarChart3 className="w-4 h-4" />,
+        bgColor: 'bg-cyan-50',
+        borderColor: 'border-cyan-200',
+        textColor: 'text-cyan-700',
+        label: 'Progress',
+      };
+    case 'agent_error':
+      return {
+        icon: <AlertCircle className="w-4 h-4" />,
+        bgColor: 'bg-red-50',
+        borderColor: 'border-red-200',
+        textColor: 'text-red-700',
+        label: 'Error',
+      };
+    case 'run_started':
+      return {
+        icon: <Play className="w-4 h-4" />,
+        bgColor: 'bg-blue-50',
+        borderColor: 'border-blue-200',
+        textColor: 'text-blue-700',
+        label: 'Run Started',
+      };
+    case 'run_completed':
+      return {
+        icon: <CheckCircle className="w-4 h-4" />,
+        bgColor: 'bg-green-50',
+        borderColor: 'border-green-200',
+        textColor: 'text-green-700',
+        label: 'Completed',
+      };
+    case 'run_failed':
+      return {
+        icon: <XCircle className="w-4 h-4" />,
+        bgColor: 'bg-red-50',
+        borderColor: 'border-red-200',
+        textColor: 'text-red-700',
+        label: 'Failed',
+      };
+    default:
+      return {
+        icon: <MessageSquare className="w-4 h-4" />,
+        bgColor: 'bg-gray-50',
+        borderColor: 'border-gray-200',
+        textColor: 'text-gray-700',
+        label: 'Event',
+      };
+  }
+}
+
+function getEventSummary(event: AgentEvent): string {
+  switch (event.type) {
+    case 'agent_tool_call': {
+      const input = event.input;
+      if (event.tool === 'Read' && input.file_path) {
+        return `Reading ${input.file_path}`;
+      }
+      if (event.tool === 'Write' && input.file_path) {
+        return `Writing ${input.file_path}`;
+      }
+      if (event.tool === 'Edit' && input.file_path) {
+        return `Editing ${input.file_path}`;
+      }
+      if (event.tool === 'Bash' && input.command) {
+        const cmd = String(input.command);
+        return cmd.length > 50 ? cmd.slice(0, 47) + '...' : cmd;
+      }
+      if (event.tool === 'Grep' && input.pattern) {
+        return `Searching for: ${input.pattern}`;
+      }
+      if (event.tool === 'Glob' && input.pattern) {
+        return `Finding files: ${input.pattern}`;
+      }
+      if ((event.tool === 'WebFetch' || event.tool === 'WebSearch') && input.url) {
+        return `Fetching ${input.url}`;
+      }
+      return `Invoking ${event.tool}`;
+    }
+    case 'agent_tool_result': {
+      const preview = event.contentPreview;
+      if (preview.length > 80) {
+        return preview.slice(0, 77) + '...';
+      }
+      return preview;
+    }
+    case 'agent_output': {
+      const content = event.content;
+      if (content.length > 100) {
+        return content.slice(0, 97) + '...';
+      }
+      return content;
+    }
+    case 'file_changed':
+      return event.path;
+    case 'progress_update':
+      return `${event.percentage}% - ${event.currentPhase}`;
+    case 'agent_error':
+      return event.message;
+    case 'run_started':
+      return `Run #${event.runNumber} started`;
+    case 'run_completed':
+      return event.prUrl ? `PR created: ${event.prUrl}` : 'Run completed successfully';
+    case 'run_failed':
+      return event.error;
+    default:
+      return 'Unknown event';
+  }
+}
+
+function getEventDetails(event: AgentEvent): string | null {
+  switch (event.type) {
+    case 'agent_tool_call':
+      return JSON.stringify(event.input, null, 2);
+    case 'agent_tool_result':
+      return event.contentPreview;
+    case 'agent_output':
+      return event.content;
+    case 'agent_error':
+      return event.details ? JSON.stringify(event.details, null, 2) : null;
+    case 'run_failed':
+      return event.error;
+    default:
+      return null;
+  }
+}
+
+function formatTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+function EventCardComponent({ event, expanded = false, onToggle }: EventCardProps) {
+  const [isExpanded, setIsExpanded] = useState(expanded);
+  const [copied, setCopied] = useState(false);
+
+  const config = getEventConfig(event);
+  const summary = getEventSummary(event);
+  const details = getEventDetails(event);
+  const hasDetails = details !== null;
+
+  const handleToggle = () => {
+    if (hasDetails) {
+      setIsExpanded(!isExpanded);
+      onToggle?.();
+    }
+  };
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (details) {
+      await navigator.clipboard.writeText(details);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div
+      className={`
+        rounded-lg border ${config.borderColor} ${config.bgColor}
+        transition-all duration-150
+      `}
+    >
+      <div
+        className={`
+          flex items-start gap-3 p-3 cursor-pointer
+          ${hasDetails ? 'hover:opacity-80' : ''}
+        `}
+        onClick={handleToggle}
+      >
+        {/* Expand/collapse chevron */}
+        <div className="flex-shrink-0 w-4 h-4 mt-0.5">
+          {hasDetails ? (
+            isExpanded ? (
+              <ChevronDown className="w-4 h-4 text-gray-500" />
+            ) : (
+              <ChevronRight className="w-4 h-4 text-gray-500" />
+            )
+          ) : null}
+        </div>
+
+        {/* Icon */}
+        <div className={`flex-shrink-0 ${config.textColor}`}>{config.icon}</div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className={`
+              text-xs font-medium px-1.5 py-0.5 rounded
+              ${config.bgColor} ${config.textColor} border ${config.borderColor}
+            `}
+            >
+              {config.label}
+            </span>
+            {event.type === 'agent_tool_result' && (
+              <span className="text-xs text-gray-500">{event.durationMs}ms</span>
+            )}
+          </div>
+          <p className="text-sm text-gray-700 mt-1 break-words font-mono">{summary}</p>
+        </div>
+
+        {/* Timestamp */}
+        <div className="flex-shrink-0 text-xs text-gray-500">{formatTime(event.timestamp)}</div>
+      </div>
+
+      {/* Expanded details */}
+      {isExpanded && hasDetails && (
+        <div className="px-3 pb-3 pt-0">
+          <div className="relative">
+            <pre className="text-xs bg-white rounded border border-gray-200 p-3 overflow-x-auto max-h-64 overflow-y-auto font-mono">
+              {details}
+            </pre>
+            <button
+              onClick={handleCopy}
+              className="absolute top-2 right-2 p-1.5 bg-white border border-gray-200 rounded hover:bg-gray-50 transition-colors"
+              title="Copy to clipboard"
+            >
+              {copied ? (
+                <Check className="w-3.5 h-3.5 text-green-600" />
+              ) : (
+                <Copy className="w-3.5 h-3.5 text-gray-500" />
+              )}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const EventCard = memo(EventCardComponent);

--- a/packages/dashboard/src/components/streaming/FilesTab.tsx
+++ b/packages/dashboard/src/components/streaming/FilesTab.tsx
@@ -1,0 +1,170 @@
+/**
+ * FilesTab - Display file changes
+ */
+
+import { useMemo } from 'react';
+import { FilePlus, FileEdit, Trash2, Folder, FileIcon } from 'lucide-react';
+import type { FileChange, FileChangeAction } from '../../types/agent-events';
+
+export interface FilesTabProps {
+  files: FileChange[];
+  className?: string;
+}
+
+interface FilesByDirectory {
+  [directory: string]: FileChange[];
+}
+
+function getActionIcon(action: FileChangeAction): React.ReactNode {
+  switch (action) {
+    case 'created':
+      return <FilePlus className="w-4 h-4 text-green-600" />;
+    case 'modified':
+      return <FileEdit className="w-4 h-4 text-yellow-600" />;
+    case 'deleted':
+      return <Trash2 className="w-4 h-4 text-red-600" />;
+  }
+}
+
+function getActionColor(action: FileChangeAction): { bg: string; text: string; border: string } {
+  switch (action) {
+    case 'created':
+      return { bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200' };
+    case 'modified':
+      return { bg: 'bg-yellow-50', text: 'text-yellow-700', border: 'border-yellow-200' };
+    case 'deleted':
+      return { bg: 'bg-red-50', text: 'text-red-700', border: 'border-red-200' };
+  }
+}
+
+function formatSize(bytes?: number): string {
+  if (bytes === undefined) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getDirectory(path: string): string {
+  const lastSlash = path.lastIndexOf('/');
+  if (lastSlash === -1) return '/';
+  return path.slice(0, lastSlash) || '/';
+}
+
+function getFileName(path: string): string {
+  const lastSlash = path.lastIndexOf('/');
+  if (lastSlash === -1) return path;
+  return path.slice(lastSlash + 1);
+}
+
+function formatTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+export function FilesTab({ files, className = '' }: FilesTabProps) {
+  // Group files by directory
+  const filesByDirectory = useMemo(() => {
+    const grouped: FilesByDirectory = {};
+    for (const file of files) {
+      const dir = getDirectory(file.path);
+      if (!grouped[dir]) {
+        grouped[dir] = [];
+      }
+      grouped[dir].push(file);
+    }
+    // Sort directories
+    const sorted: FilesByDirectory = {};
+    Object.keys(grouped)
+      .sort()
+      .forEach((key) => {
+        sorted[key] = grouped[key];
+      });
+    return sorted;
+  }, [files]);
+
+  // Stats
+  const stats = useMemo(() => {
+    const created = files.filter((f) => f.action === 'created').length;
+    const modified = files.filter((f) => f.action === 'modified').length;
+    const deleted = files.filter((f) => f.action === 'deleted').length;
+    return { total: files.length, created, modified, deleted };
+  }, [files]);
+
+  if (files.length === 0) {
+    return (
+      <div className={`flex flex-col items-center justify-center py-12 text-gray-500 ${className}`}>
+        <FileIcon className="w-8 h-8 text-gray-300 mb-2" />
+        <p className="text-sm">No file changes yet</p>
+        <p className="text-xs mt-1">Files created, modified, or deleted will appear here</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col ${className}`}>
+      {/* Stats */}
+      <div className="flex items-center gap-4 text-xs mb-4">
+        <span className="text-gray-600">Total: {stats.total}</span>
+        <span className="text-green-600">Created: {stats.created}</span>
+        <span className="text-yellow-600">Modified: {stats.modified}</span>
+        <span className="text-red-600">Deleted: {stats.deleted}</span>
+      </div>
+
+      {/* File tree */}
+      <div className="flex-1 overflow-y-auto max-h-[500px] space-y-4">
+        {Object.entries(filesByDirectory).map(([directory, dirFiles]) => (
+          <div key={directory} className="rounded-lg border border-gray-200 overflow-hidden">
+            {/* Directory header */}
+            <div className="flex items-center gap-2 px-3 py-2 bg-gray-50 border-b border-gray-200">
+              <Folder className="w-4 h-4 text-gray-500" />
+              <span className="text-sm font-medium text-gray-700 font-mono">{directory}</span>
+              <span className="text-xs text-gray-500">({dirFiles.length} files)</span>
+            </div>
+
+            {/* Files in directory */}
+            <div className="divide-y divide-gray-100">
+              {dirFiles.map((file) => {
+                const colors = getActionColor(file.action);
+                return (
+                  <div
+                    key={file.path}
+                    className={`flex items-center gap-3 px-3 py-2 ${colors.bg}`}
+                  >
+                    {/* Action icon */}
+                    {getActionIcon(file.action)}
+
+                    {/* File name */}
+                    <span className="flex-1 text-sm font-mono text-gray-700 truncate">
+                      {getFileName(file.path)}
+                    </span>
+
+                    {/* Action badge */}
+                    <span
+                      className={`text-xs px-1.5 py-0.5 rounded ${colors.bg} ${colors.text} border ${colors.border}`}
+                    >
+                      {file.action}
+                    </span>
+
+                    {/* Size */}
+                    {file.sizeBytes !== undefined && (
+                      <span className="text-xs text-gray-500 w-16 text-right">
+                        {formatSize(file.sizeBytes)}
+                      </span>
+                    )}
+
+                    {/* Time */}
+                    <span className="text-xs text-gray-500">{formatTime(file.timestamp)}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/streaming/OutputTab.tsx
+++ b/packages/dashboard/src/components/streaming/OutputTab.tsx
@@ -1,0 +1,122 @@
+/**
+ * OutputTab - Display agent text output
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import { Copy, Check, Search, MessageSquare } from 'lucide-react';
+import type { AgentOutputEvent } from '../../types/agent-events';
+
+export interface OutputTabProps {
+  outputs: AgentOutputEvent[];
+  className?: string;
+}
+
+function formatTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+export function OutputTab({ outputs, className = '' }: OutputTabProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  // Filter outputs by search query
+  const filteredOutputs = useMemo(() => {
+    if (!searchQuery) return outputs;
+    const query = searchQuery.toLowerCase();
+    return outputs.filter((o) => o.content.toLowerCase().includes(query));
+  }, [outputs, searchQuery]);
+
+  // Combine all output for copy
+  const allOutput = useMemo(() => {
+    return outputs.map((o) => o.content).join('\n\n');
+  }, [outputs]);
+
+  // Copy all output
+  const handleCopyAll = useCallback(async () => {
+    await navigator.clipboard.writeText(allOutput);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [allOutput]);
+
+  return (
+    <div className={`flex flex-col ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-600">{outputs.length} messages</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search output..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="text-xs border border-gray-200 rounded pl-7 pr-2 py-1.5 w-40 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+
+          {/* Copy all */}
+          <button
+            onClick={handleCopyAll}
+            disabled={outputs.length === 0}
+            className="flex items-center gap-1 px-2 py-1 text-xs border border-gray-200 rounded hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {copied ? (
+              <>
+                <Check className="w-3.5 h-3.5 text-green-600" />
+                <span className="text-green-600">Copied</span>
+              </>
+            ) : (
+              <>
+                <Copy className="w-3.5 h-3.5 text-gray-500" />
+                <span>Copy All</span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Output content */}
+      <div className="flex-1 overflow-y-auto max-h-[500px]">
+        {filteredOutputs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-500">
+            <MessageSquare className="w-8 h-8 text-gray-300 mb-2" />
+            <p className="text-sm">No output yet</p>
+            {searchQuery ? (
+              <p className="text-xs mt-1">Try adjusting your search</p>
+            ) : (
+              <p className="text-xs mt-1">Agent output will appear here</p>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {filteredOutputs.map((output, index) => (
+              <div
+                key={`${output.timestamp}-${index}`}
+                className="bg-gray-50 rounded-lg border border-gray-200 p-3"
+              >
+                <div className="flex items-start justify-between mb-2">
+                  <span className="text-xs text-gray-500">{formatTime(output.timestamp)}</span>
+                </div>
+                <div className="prose prose-sm max-w-none">
+                  <pre className="whitespace-pre-wrap text-sm text-gray-700 font-mono bg-white rounded border border-gray-100 p-3 overflow-x-auto">
+                    {output.content}
+                  </pre>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/streaming/ProgressHeader.tsx
+++ b/packages/dashboard/src/components/streaming/ProgressHeader.tsx
@@ -1,0 +1,104 @@
+/**
+ * ProgressHeader - Progress indicator for run execution
+ */
+
+import { Clock, Wrench, BarChart3 } from 'lucide-react';
+import type { ProgressState } from '../../types/agent-events';
+
+export interface ProgressHeaderProps {
+  progress: ProgressState | null;
+  className?: string;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) {
+    return `${Math.round(seconds)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  if (minutes < 60) {
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+export function ProgressHeader({ progress, className = '' }: ProgressHeaderProps) {
+  if (!progress) {
+    return (
+      <div className={`bg-gray-50 rounded-lg border border-gray-200 p-4 ${className}`}>
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center">
+            <BarChart3 className="w-4 h-4 text-gray-400" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-500">Waiting for progress...</p>
+            <p className="text-xs text-gray-400">Progress data will appear once the agent starts</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const { percentage, currentPhase, toolCallCount, elapsedSeconds, estimatedRemainingSeconds } =
+    progress;
+
+  return (
+    <div className={`bg-white rounded-lg border border-gray-200 p-4 ${className}`}>
+      {/* Progress bar */}
+      <div className="mb-4">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm font-medium text-gray-700">{currentPhase}</span>
+          <span className="text-sm font-semibold text-blue-600">{percentage}%</span>
+        </div>
+        <div className="w-full h-2 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-blue-600 rounded-full transition-all duration-300 ease-out"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="flex items-center gap-6 text-sm">
+        {/* Tool calls */}
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-full bg-purple-50 flex items-center justify-center">
+            <Wrench className="w-3.5 h-3.5 text-purple-600" />
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Tool Calls</p>
+            <p className="font-semibold text-gray-900">{toolCallCount}</p>
+          </div>
+        </div>
+
+        {/* Elapsed time */}
+        <div className="flex items-center gap-2">
+          <div className="w-7 h-7 rounded-full bg-blue-50 flex items-center justify-center">
+            <Clock className="w-3.5 h-3.5 text-blue-600" />
+          </div>
+          <div>
+            <p className="text-xs text-gray-500">Elapsed</p>
+            <p className="font-semibold text-gray-900">{formatDuration(elapsedSeconds)}</p>
+          </div>
+        </div>
+
+        {/* ETA */}
+        {estimatedRemainingSeconds !== undefined && estimatedRemainingSeconds > 0 && (
+          <div className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-full bg-green-50 flex items-center justify-center">
+              <Clock className="w-3.5 h-3.5 text-green-600" />
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">ETA</p>
+              <p className="font-semibold text-gray-900">
+                {formatDuration(estimatedRemainingSeconds)}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/streaming/RunStreamView.tsx
+++ b/packages/dashboard/src/components/streaming/RunStreamView.tsx
@@ -1,0 +1,196 @@
+/**
+ * RunStreamView - Comprehensive run detail view with tabbed streaming output
+ */
+
+import { useState, useEffect } from 'react';
+import { Activity, Wrench, MessageSquare, FileIcon, AlertCircle } from 'lucide-react';
+import { ProgressHeader } from './ProgressHeader';
+import { AgentActivityPanel } from './AgentActivityPanel';
+import { ToolCallsTab } from './ToolCallsTab';
+import { OutputTab } from './OutputTab';
+import { FilesTab } from './FilesTab';
+import { ErrorsTab } from './ErrorsTab';
+import { useRunStream } from '../../hooks/useRunStream';
+
+export interface RunStreamViewProps {
+  workOrderId: string;
+  maxEvents?: number;
+  className?: string;
+}
+
+type TabId = 'activity' | 'tools' | 'output' | 'files' | 'errors';
+
+interface TabConfig {
+  id: TabId;
+  label: string;
+  icon: React.ReactNode;
+  getBadge?: () => number | undefined;
+}
+
+export function RunStreamView({
+  workOrderId,
+  maxEvents = 500,
+  className = '',
+}: RunStreamViewProps) {
+  const [activeTab, setActiveTab] = useState<TabId>('activity');
+
+  const {
+    events,
+    toolCalls,
+    files,
+    errors,
+    outputs,
+    progress,
+    isSubscribed,
+    connectionState,
+    subscribe,
+    unsubscribe,
+  } = useRunStream({ maxEvents });
+
+  // Subscribe on mount
+  useEffect(() => {
+    if (workOrderId) {
+      subscribe(workOrderId);
+    }
+    return () => {
+      unsubscribe();
+    };
+  }, [workOrderId, subscribe, unsubscribe]);
+
+  const tabs: TabConfig[] = [
+    {
+      id: 'activity',
+      label: 'Activity',
+      icon: <Activity className="w-4 h-4" />,
+      getBadge: () => (events.length > 0 ? events.length : undefined),
+    },
+    {
+      id: 'tools',
+      label: 'Tools',
+      icon: <Wrench className="w-4 h-4" />,
+      getBadge: () => (toolCalls.length > 0 ? toolCalls.length : undefined),
+    },
+    {
+      id: 'output',
+      label: 'Output',
+      icon: <MessageSquare className="w-4 h-4" />,
+      getBadge: () => (outputs.length > 0 ? outputs.length : undefined),
+    },
+    {
+      id: 'files',
+      label: 'Files',
+      icon: <FileIcon className="w-4 h-4" />,
+      getBadge: () => (files.length > 0 ? files.length : undefined),
+    },
+    {
+      id: 'errors',
+      label: 'Errors',
+      icon: <AlertCircle className="w-4 h-4" />,
+      getBadge: () => (errors.length > 0 ? errors.length : undefined),
+    },
+  ];
+
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case 'activity':
+        return (
+          <AgentActivityPanel
+            workOrderId={workOrderId}
+            maxEvents={maxEvents}
+            autoScroll={true}
+            className="border-0"
+          />
+        );
+      case 'tools':
+        return <ToolCallsTab toolCalls={toolCalls} />;
+      case 'output':
+        return <OutputTab outputs={outputs} />;
+      case 'files':
+        return <FilesTab files={files} />;
+      case 'errors':
+        return <ErrorsTab errors={errors} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className={`flex flex-col bg-white rounded-lg border border-gray-200 ${className}`}>
+      {/* Progress header */}
+      <ProgressHeader progress={progress} className="border-b border-gray-200 rounded-none rounded-t-lg" />
+
+      {/* Tab navigation */}
+      <div className="flex border-b border-gray-200">
+        {tabs.map((tab) => {
+          const badge = tab.getBadge?.();
+          const isActive = activeTab === tab.id;
+          const hasErrors = tab.id === 'errors' && errors.length > 0;
+
+          return (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`
+                flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors
+                ${isActive
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-600 hover:text-gray-900 hover:border-gray-300'
+                }
+                ${hasErrors && !isActive ? 'text-red-600' : ''}
+              `}
+            >
+              <span className={hasErrors && !isActive ? 'text-red-600' : ''}>{tab.icon}</span>
+              <span>{tab.label}</span>
+              {badge !== undefined && (
+                <span
+                  className={`
+                    px-1.5 py-0.5 text-xs rounded-full
+                    ${isActive
+                      ? 'bg-blue-100 text-blue-700'
+                      : hasErrors
+                        ? 'bg-red-100 text-red-700'
+                        : 'bg-gray-100 text-gray-600'
+                    }
+                  `}
+                >
+                  {badge > 99 ? '99+' : badge}
+                </span>
+              )}
+            </button>
+          );
+        })}
+
+        {/* Connection status */}
+        <div className="flex items-center ml-auto px-4">
+          <div className="flex items-center gap-2">
+            <span
+              className={`
+                w-2 h-2 rounded-full
+                ${connectionState === 'connected' && isSubscribed
+                  ? 'bg-green-500 animate-pulse'
+                  : connectionState === 'connecting'
+                    ? 'bg-yellow-500 animate-pulse'
+                    : connectionState === 'error'
+                      ? 'bg-red-500'
+                      : 'bg-gray-400'
+                }
+              `}
+            />
+            <span className="text-xs text-gray-500">
+              {connectionState === 'connected' && isSubscribed
+                ? 'Live'
+                : connectionState === 'connecting'
+                  ? 'Connecting...'
+                  : connectionState === 'error'
+                    ? 'Error'
+                    : 'Disconnected'}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 p-4 min-h-[400px]">{renderTabContent()}</div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/streaming/ToolCallsTab.tsx
+++ b/packages/dashboard/src/components/streaming/ToolCallsTab.tsx
@@ -1,0 +1,367 @@
+/**
+ * ToolCallsTab - Display tool calls in structured format
+ */
+
+import { useState, useMemo, memo } from 'react';
+import {
+  BookOpen,
+  FileEdit,
+  Pencil,
+  Terminal,
+  Search,
+  FolderSearch,
+  Globe,
+  ChevronDown,
+  ChevronRight,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Filter,
+  Copy,
+  Check,
+} from 'lucide-react';
+import type { ToolCallWithResult, AgentToolName } from '../../types/agent-events';
+
+export interface ToolCallsTabProps {
+  toolCalls: ToolCallWithResult[];
+  className?: string;
+}
+
+interface ToolCallItemProps {
+  toolCall: ToolCallWithResult;
+}
+
+function getToolIcon(tool: AgentToolName): React.ReactNode {
+  switch (tool) {
+    case 'Read':
+      return <BookOpen className="w-4 h-4" />;
+    case 'Write':
+      return <FileEdit className="w-4 h-4" />;
+    case 'Edit':
+      return <Pencil className="w-4 h-4" />;
+    case 'Bash':
+      return <Terminal className="w-4 h-4" />;
+    case 'Grep':
+      return <Search className="w-4 h-4" />;
+    case 'Glob':
+      return <FolderSearch className="w-4 h-4" />;
+    case 'WebFetch':
+    case 'WebSearch':
+      return <Globe className="w-4 h-4" />;
+    default:
+      return <Terminal className="w-4 h-4" />;
+  }
+}
+
+function getToolColor(tool: AgentToolName): { bg: string; text: string; border: string } {
+  switch (tool) {
+    case 'Read':
+      return { bg: 'bg-blue-50', text: 'text-blue-700', border: 'border-blue-200' };
+    case 'Write':
+    case 'Edit':
+      return { bg: 'bg-green-50', text: 'text-green-700', border: 'border-green-200' };
+    case 'Bash':
+      return { bg: 'bg-yellow-50', text: 'text-yellow-700', border: 'border-yellow-200' };
+    case 'Grep':
+    case 'Glob':
+      return { bg: 'bg-purple-50', text: 'text-purple-700', border: 'border-purple-200' };
+    case 'WebFetch':
+    case 'WebSearch':
+      return { bg: 'bg-cyan-50', text: 'text-cyan-700', border: 'border-cyan-200' };
+    default:
+      return { bg: 'bg-gray-50', text: 'text-gray-700', border: 'border-gray-200' };
+  }
+}
+
+function getToolSummary(toolCall: ToolCallWithResult): string {
+  const { call } = toolCall;
+  const input = call.input;
+
+  switch (call.tool) {
+    case 'Read':
+      return input.file_path ? String(input.file_path) : 'Reading file...';
+    case 'Write':
+      return input.file_path ? String(input.file_path) : 'Writing file...';
+    case 'Edit':
+      return input.file_path ? String(input.file_path) : 'Editing file...';
+    case 'Bash': {
+      const cmd = input.command ? String(input.command) : 'Executing command...';
+      return cmd.length > 60 ? cmd.slice(0, 57) + '...' : cmd;
+    }
+    case 'Grep':
+      return input.pattern ? `Pattern: ${input.pattern}` : 'Searching...';
+    case 'Glob':
+      return input.pattern ? `Pattern: ${input.pattern}` : 'Finding files...';
+    case 'WebFetch':
+    case 'WebSearch':
+      return input.url ? String(input.url) : 'Fetching...';
+    default:
+      return 'Executing...';
+  }
+}
+
+function ToolCallItemComponent({ toolCall }: ToolCallItemProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [copiedInput, setCopiedInput] = useState(false);
+  const [copiedOutput, setCopiedOutput] = useState(false);
+
+  const { call, result } = toolCall;
+  const colors = getToolColor(call.tool);
+  const isPending = !result;
+  const isSuccess = result?.success ?? true;
+
+  const handleCopyInput = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await navigator.clipboard.writeText(JSON.stringify(call.input, null, 2));
+    setCopiedInput(true);
+    setTimeout(() => setCopiedInput(false), 2000);
+  };
+
+  const handleCopyOutput = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (result) {
+      await navigator.clipboard.writeText(result.contentPreview);
+      setCopiedOutput(true);
+      setTimeout(() => setCopiedOutput(false), 2000);
+    }
+  };
+
+  return (
+    <div className={`rounded-lg border ${colors.border} ${colors.bg} overflow-hidden`}>
+      {/* Header */}
+      <div
+        className="flex items-start gap-3 p-3 cursor-pointer hover:opacity-80 transition-opacity"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        {/* Expand chevron */}
+        <div className="flex-shrink-0 w-4 h-4 mt-0.5">
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-gray-500" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-gray-500" />
+          )}
+        </div>
+
+        {/* Tool icon */}
+        <div className={`flex-shrink-0 ${colors.text}`}>{getToolIcon(call.tool)}</div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className={`text-xs font-medium px-1.5 py-0.5 rounded ${colors.bg} ${colors.text} border ${colors.border}`}
+            >
+              {call.tool}
+            </span>
+
+            {/* Status indicator */}
+            {isPending ? (
+              <span className="flex items-center gap-1 text-xs text-yellow-600">
+                <Clock className="w-3 h-3 animate-spin" />
+                Pending
+              </span>
+            ) : isSuccess ? (
+              <span className="flex items-center gap-1 text-xs text-green-600">
+                <CheckCircle className="w-3 h-3" />
+                Success
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 text-xs text-red-600">
+                <XCircle className="w-3 h-3" />
+                Failed
+              </span>
+            )}
+
+            {/* Duration */}
+            {result && (
+              <span className="text-xs text-gray-500">{result.durationMs}ms</span>
+            )}
+          </div>
+
+          <p className="text-sm text-gray-700 mt-1 truncate font-mono">
+            {getToolSummary(toolCall)}
+          </p>
+        </div>
+
+        {/* Timestamp */}
+        <div className="flex-shrink-0 text-xs text-gray-500">
+          {new Date(call.timestamp).toLocaleTimeString('en-US', {
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+          })}
+        </div>
+      </div>
+
+      {/* Expanded content */}
+      {isExpanded && (
+        <div className="px-3 pb-3 pt-0 space-y-3">
+          {/* Input */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-xs font-medium text-gray-600">Input</span>
+              <button
+                onClick={handleCopyInput}
+                className="p-1 hover:bg-white rounded transition-colors"
+                title="Copy input"
+              >
+                {copiedInput ? (
+                  <Check className="w-3 h-3 text-green-600" />
+                ) : (
+                  <Copy className="w-3 h-3 text-gray-500" />
+                )}
+              </button>
+            </div>
+            <pre className="text-xs bg-white rounded border border-gray-200 p-2 overflow-x-auto max-h-40 overflow-y-auto font-mono">
+              {JSON.stringify(call.input, null, 2)}
+            </pre>
+          </div>
+
+          {/* Output */}
+          {result && (
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs font-medium text-gray-600">
+                  Output ({result.contentLength} chars)
+                </span>
+                <button
+                  onClick={handleCopyOutput}
+                  className="p-1 hover:bg-white rounded transition-colors"
+                  title="Copy output"
+                >
+                  {copiedOutput ? (
+                    <Check className="w-3 h-3 text-green-600" />
+                  ) : (
+                    <Copy className="w-3 h-3 text-gray-500" />
+                  )}
+                </button>
+              </div>
+              <pre
+                className={`
+                  text-xs rounded border p-2 overflow-x-auto max-h-40 overflow-y-auto font-mono
+                  ${result.success ? 'bg-white border-gray-200' : 'bg-red-50 border-red-200'}
+                `}
+              >
+                {result.contentPreview}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const ToolCallItem = memo(ToolCallItemComponent);
+
+const TOOL_OPTIONS: AgentToolName[] = [
+  'Read',
+  'Write',
+  'Edit',
+  'Bash',
+  'Grep',
+  'Glob',
+  'WebFetch',
+  'WebSearch',
+  'Other',
+];
+
+export function ToolCallsTab({ toolCalls, className = '' }: ToolCallsTabProps) {
+  const [filterTool, setFilterTool] = useState<AgentToolName | 'all'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Filter tool calls
+  const filteredToolCalls = useMemo(() => {
+    return toolCalls.filter((tc) => {
+      // Tool filter
+      if (filterTool !== 'all' && tc.call.tool !== filterTool) {
+        return false;
+      }
+
+      // Search filter
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase();
+        const inputStr = JSON.stringify(tc.call.input).toLowerCase();
+        const resultStr = tc.result?.contentPreview.toLowerCase() || '';
+        return inputStr.includes(query) || resultStr.includes(query);
+      }
+
+      return true;
+    });
+  }, [toolCalls, filterTool, searchQuery]);
+
+  // Stats
+  const stats = useMemo(() => {
+    const total = toolCalls.length;
+    const successful = toolCalls.filter((tc) => tc.result?.success).length;
+    const failed = toolCalls.filter((tc) => tc.result && !tc.result.success).length;
+    const pending = toolCalls.filter((tc) => !tc.result).length;
+    return { total, successful, failed, pending };
+  }, [toolCalls]);
+
+  return (
+    <div className={`flex flex-col ${className}`}>
+      {/* Header with filters */}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 mb-4">
+        {/* Stats */}
+        <div className="flex items-center gap-4 text-xs">
+          <span className="text-gray-600">Total: {stats.total}</span>
+          <span className="text-green-600">Success: {stats.successful}</span>
+          <span className="text-red-600">Failed: {stats.failed}</span>
+          {stats.pending > 0 && (
+            <span className="text-yellow-600">Pending: {stats.pending}</span>
+          )}
+        </div>
+
+        {/* Filters */}
+        <div className="flex items-center gap-2 ml-auto">
+          {/* Tool filter */}
+          <div className="flex items-center gap-1">
+            <Filter className="w-3.5 h-3.5 text-gray-400" />
+            <select
+              value={filterTool}
+              onChange={(e) => setFilterTool(e.target.value as AgentToolName | 'all')}
+              className="text-xs border border-gray-200 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="all">All Tools</option>
+              {TOOL_OPTIONS.map((tool) => (
+                <option key={tool} value={tool}>
+                  {tool}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Search */}
+          <input
+            type="text"
+            placeholder="Search..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="text-xs border border-gray-200 rounded px-2 py-1 w-32 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+
+      {/* Tool calls list */}
+      <div className="flex-1 overflow-y-auto space-y-2 max-h-[500px]">
+        {filteredToolCalls.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-500">
+            <Terminal className="w-8 h-8 text-gray-300 mb-2" />
+            <p className="text-sm">No tool calls yet</p>
+            {filterTool !== 'all' || searchQuery ? (
+              <p className="text-xs mt-1">Try adjusting your filters</p>
+            ) : (
+              <p className="text-xs mt-1">Tool calls will appear here as the agent works</p>
+            )}
+          </div>
+        ) : (
+          filteredToolCalls.map((tc) => (
+            <ToolCallItem key={tc.call.toolUseId} toolCall={tc} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/streaming/__tests__/EventCard.test.tsx
+++ b/packages/dashboard/src/components/streaming/__tests__/EventCard.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * EventCard component tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '../../../test/utils';
+import { EventCard } from '../EventCard';
+import type {
+  AgentToolCallEvent,
+  AgentToolResultEvent,
+  AgentOutputEvent,
+  FileChangedEvent,
+  ProgressUpdateEvent,
+  AgentErrorEvent,
+} from '../../../types/agent-events';
+
+describe('EventCard', () => {
+  const baseTimestamp = '2024-01-15T10:30:00.000Z';
+
+  beforeEach(() => {
+    // Mock clipboard API
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('tool call events', () => {
+    it('renders Read tool call with file path', () => {
+      const event: AgentToolCallEvent = {
+        type: 'agent_tool_call',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        toolUseId: 'toolu-1',
+        tool: 'Read',
+        input: { file_path: '/workspace/src/index.ts' },
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Read')).toBeTruthy();
+      expect(screen.getByText(/Reading \/workspace\/src\/index\.ts/)).toBeTruthy();
+    });
+
+    it('renders Bash tool call with command', () => {
+      const event: AgentToolCallEvent = {
+        type: 'agent_tool_call',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        toolUseId: 'toolu-2',
+        tool: 'Bash',
+        input: { command: 'npm install' },
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Bash')).toBeTruthy();
+      expect(screen.getByText('npm install')).toBeTruthy();
+    });
+
+    it('truncates long commands', () => {
+      const longCommand = 'a'.repeat(100);
+      const event: AgentToolCallEvent = {
+        type: 'agent_tool_call',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        toolUseId: 'toolu-3',
+        tool: 'Bash',
+        input: { command: longCommand },
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      const displayedText = screen.getByText(/aaa/);
+      expect(displayedText.textContent?.length).toBeLessThan(longCommand.length);
+      expect(displayedText.textContent).toContain('...');
+    });
+  });
+
+  describe('tool result events', () => {
+    it('renders successful result', () => {
+      const event: AgentToolResultEvent = {
+        type: 'agent_tool_result',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        toolUseId: 'toolu-1',
+        success: true,
+        contentPreview: 'File contents here',
+        contentLength: 18,
+        durationMs: 42,
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Success')).toBeTruthy();
+      expect(screen.getByText('42ms')).toBeTruthy();
+    });
+
+    it('renders failed result with error styling', () => {
+      const event: AgentToolResultEvent = {
+        type: 'agent_tool_result',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        toolUseId: 'toolu-1',
+        success: false,
+        contentPreview: 'Error: File not found',
+        contentLength: 21,
+        durationMs: 5,
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Error')).toBeTruthy();
+    });
+  });
+
+  describe('agent output events', () => {
+    it('renders output text', () => {
+      const event: AgentOutputEvent = {
+        type: 'agent_output',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        content: 'I will help you implement this feature.',
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Output')).toBeTruthy();
+      expect(screen.getByText(/I will help you implement this feature/)).toBeTruthy();
+    });
+  });
+
+  describe('file changed events', () => {
+    it('renders file created event', () => {
+      const event: FileChangedEvent = {
+        type: 'file_changed',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        path: '/workspace/src/new-file.ts',
+        action: 'created',
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Created')).toBeTruthy();
+      expect(screen.getByText('/workspace/src/new-file.ts')).toBeTruthy();
+    });
+
+    it('renders file modified event', () => {
+      const event: FileChangedEvent = {
+        type: 'file_changed',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        path: '/workspace/src/index.ts',
+        action: 'modified',
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Modified')).toBeTruthy();
+    });
+
+    it('renders file deleted event', () => {
+      const event: FileChangedEvent = {
+        type: 'file_changed',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        path: '/workspace/src/old-file.ts',
+        action: 'deleted',
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Deleted')).toBeTruthy();
+    });
+  });
+
+  describe('progress update events', () => {
+    it('renders progress with percentage', () => {
+      const event: ProgressUpdateEvent = {
+        type: 'progress_update',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        percentage: 45,
+        currentPhase: 'Reading files',
+        toolCallCount: 10,
+        elapsedSeconds: 30,
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Progress')).toBeTruthy();
+      expect(screen.getByText('45% - Reading files')).toBeTruthy();
+    });
+  });
+
+  describe('error events', () => {
+    it('renders error message', () => {
+      const event: AgentErrorEvent = {
+        type: 'agent_error',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        message: 'Something went wrong',
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      expect(screen.getByText('Error')).toBeTruthy();
+      expect(screen.getByText('Something went wrong')).toBeTruthy();
+    });
+  });
+
+  describe('expand/collapse behavior', () => {
+    it('expands on click for events with details', () => {
+      const event: AgentToolCallEvent = {
+        type: 'agent_tool_call',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        toolUseId: 'toolu-1',
+        tool: 'Read',
+        input: { file_path: '/workspace/file.ts' },
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      // Click to expand
+      fireEvent.click(screen.getByText(/Reading/));
+
+      // Should show the JSON input
+      expect(screen.getByText(/"file_path"/)).toBeTruthy();
+    });
+  });
+
+  describe('copy functionality', () => {
+    it('copies content to clipboard', async () => {
+      const event: AgentToolCallEvent = {
+        type: 'agent_tool_call',
+        workOrderId: 'wo-1',
+        runId: 'run-1',
+        toolUseId: 'toolu-1',
+        tool: 'Read',
+        input: { file_path: '/workspace/file.ts' },
+        timestamp: baseTimestamp,
+      };
+
+      render(<EventCard event={event} />);
+
+      // Expand first
+      fireEvent.click(screen.getByText(/Reading/));
+
+      // Click copy button
+      const copyButton = screen.getByTitle('Copy to clipboard');
+      fireEvent.click(copyButton);
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('file_path')
+      );
+    });
+  });
+});

--- a/packages/dashboard/src/components/streaming/index.ts
+++ b/packages/dashboard/src/components/streaming/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Streaming components exports
+ */
+
+export * from './EventCard';
+export * from './AgentActivityPanel';
+export * from './ProgressHeader';
+export * from './ToolCallsTab';
+export * from './OutputTab';
+export * from './FilesTab';
+export * from './ErrorsTab';
+export * from './RunStreamView';

--- a/packages/dashboard/src/hooks/__tests__/useRunStream.test.tsx
+++ b/packages/dashboard/src/hooks/__tests__/useRunStream.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * useRunStream hook tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '../../test/utils';
+import { useRunStream } from '../useRunStream';
+
+// Mock the websocket module
+vi.mock('../../api/websocket', () => {
+  const mockWsClient = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    subscribe: vi.fn().mockReturnValue(() => {}),
+    send: vi.fn().mockReturnValue(true),
+    isConnected: vi.fn().mockReturnValue(true),
+    getConnectionState: vi.fn().mockReturnValue('connected' as const),
+  };
+
+  return {
+    getWebSocketClient: vi.fn().mockReturnValue(mockWsClient),
+    // Need to also export the types
+    ConnectionState: {},
+  };
+});
+
+// Get reference to the mock after it's defined
+import { getWebSocketClient } from '../../api/websocket';
+
+describe('useRunStream', () => {
+  let mockWsClient: ReturnType<typeof getWebSocketClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWsClient = getWebSocketClient();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('should initialize with empty state', () => {
+      const { result } = renderHook(() => useRunStream());
+
+      expect(result.current.events).toEqual([]);
+      expect(result.current.toolCalls).toEqual([]);
+      expect(result.current.files).toEqual([]);
+      expect(result.current.errors).toEqual([]);
+      expect(result.current.outputs).toEqual([]);
+      expect(result.current.progress).toBeNull();
+      expect(result.current.isSubscribed).toBe(false);
+    });
+
+    it('should auto-connect by default', () => {
+      renderHook(() => useRunStream());
+
+      expect(mockWsClient.connect).toHaveBeenCalled();
+    });
+
+    it('should not auto-connect when disabled', () => {
+      (mockWsClient.connect as ReturnType<typeof vi.fn>).mockClear();
+      renderHook(() => useRunStream({ autoConnect: false }));
+
+      expect(mockWsClient.connect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscription', () => {
+    it('should subscribe to work order', () => {
+      const { result } = renderHook(() => useRunStream());
+
+      act(() => {
+        result.current.subscribe('wo-123');
+      });
+
+      expect(mockWsClient.send).toHaveBeenCalledWith({
+        type: 'subscribe',
+        workOrderId: 'wo-123',
+        filters: undefined,
+      });
+    });
+
+    it('should unsubscribe from work order', () => {
+      const { result } = renderHook(() => useRunStream());
+
+      act(() => {
+        result.current.subscribe('wo-123');
+      });
+
+      act(() => {
+        result.current.unsubscribe();
+      });
+
+      expect(mockWsClient.send).toHaveBeenCalledWith({
+        type: 'unsubscribe',
+        workOrderId: 'wo-123',
+      });
+    });
+  });
+
+  describe('clear events', () => {
+    it('should clear all events', () => {
+      const { result } = renderHook(() => useRunStream());
+
+      // Clear events (even if empty)
+      act(() => {
+        result.current.clearEvents();
+      });
+
+      expect(result.current.events).toEqual([]);
+      expect(result.current.outputs).toEqual([]);
+    });
+  });
+
+  describe('exposed state', () => {
+    it('should expose connection state', () => {
+      const { result } = renderHook(() => useRunStream());
+
+      expect(result.current.connectionState).toBeDefined();
+    });
+
+    it('should expose subscribe and unsubscribe functions', () => {
+      const { result } = renderHook(() => useRunStream());
+
+      expect(typeof result.current.subscribe).toBe('function');
+      expect(typeof result.current.unsubscribe).toBe('function');
+    });
+
+    it('should expose clearEvents function', () => {
+      const { result } = renderHook(() => useRunStream());
+
+      expect(typeof result.current.clearEvents).toBe('function');
+    });
+  });
+});

--- a/packages/dashboard/src/hooks/index.ts
+++ b/packages/dashboard/src/hooks/index.ts
@@ -9,3 +9,4 @@ export * from './useCreateWorkOrder';
 export * from './useCancelWorkOrder';
 export * from './useRuns';
 export * from './useRun';
+export * from './useRunStream';

--- a/packages/dashboard/src/hooks/useRunStream.ts
+++ b/packages/dashboard/src/hooks/useRunStream.ts
@@ -1,0 +1,341 @@
+/**
+ * React hook for streaming run events
+ */
+
+import { useEffect, useState, useCallback, useRef, useReducer } from 'react';
+import {
+  getWebSocketClient,
+  type WebSocketMessage,
+  type ConnectionState,
+} from '../api/websocket';
+import type {
+  AgentEvent,
+  ToolCallWithResult,
+  FileChange,
+  ProgressState,
+  AgentErrorEvent,
+  AgentOutputEvent,
+  SubscriptionFilters,
+} from '../types/agent-events';
+
+export interface UseRunStreamOptions {
+  maxEvents?: number;
+  filters?: SubscriptionFilters;
+  autoConnect?: boolean;
+}
+
+export interface UseRunStreamResult {
+  events: AgentEvent[];
+  toolCalls: ToolCallWithResult[];
+  files: FileChange[];
+  errors: AgentErrorEvent[];
+  outputs: AgentOutputEvent[];
+  progress: ProgressState | null;
+  isSubscribed: boolean;
+  isConnected: boolean;
+  connectionState: ConnectionState;
+  subscribe: (workOrderId: string) => void;
+  unsubscribe: () => void;
+  clearEvents: () => void;
+}
+
+interface StreamState {
+  events: AgentEvent[];
+  toolCalls: Map<string, ToolCallWithResult>;
+  files: Map<string, FileChange>;
+  errors: AgentErrorEvent[];
+  outputs: AgentOutputEvent[];
+  progress: ProgressState | null;
+}
+
+type StreamAction =
+  | { type: 'ADD_EVENT'; event: AgentEvent; maxEvents: number }
+  | { type: 'SET_PROGRESS'; progress: ProgressState }
+  | { type: 'CLEAR' };
+
+function streamReducer(state: StreamState, action: StreamAction): StreamState {
+  switch (action.type) {
+    case 'ADD_EVENT': {
+      const event = action.event;
+      const newEvents = [...state.events, event];
+
+      // Limit events array size
+      if (newEvents.length > action.maxEvents) {
+        newEvents.splice(0, newEvents.length - action.maxEvents);
+      }
+
+      const newState: StreamState = {
+        ...state,
+        events: newEvents,
+      };
+
+      // Process event by type
+      switch (event.type) {
+        case 'agent_tool_call': {
+          const newToolCalls = new Map(state.toolCalls);
+          newToolCalls.set(event.toolUseId, { call: event });
+          newState.toolCalls = newToolCalls;
+          break;
+        }
+        case 'agent_tool_result': {
+          const newToolCalls = new Map(state.toolCalls);
+          const existing = newToolCalls.get(event.toolUseId);
+          if (existing) {
+            newToolCalls.set(event.toolUseId, { ...existing, result: event });
+          } else {
+            // Result without a matching call - create a placeholder
+            newToolCalls.set(event.toolUseId, {
+              call: {
+                type: 'agent_tool_call',
+                workOrderId: event.workOrderId,
+                runId: event.runId,
+                toolUseId: event.toolUseId,
+                tool: 'Other',
+                input: {},
+                timestamp: event.timestamp,
+              },
+              result: event,
+            });
+          }
+          newState.toolCalls = newToolCalls;
+          break;
+        }
+        case 'file_changed': {
+          const newFiles = new Map(state.files);
+          newFiles.set(event.path, {
+            path: event.path,
+            action: event.action,
+            sizeBytes: event.sizeBytes,
+            timestamp: event.timestamp,
+          });
+          newState.files = newFiles;
+          break;
+        }
+        case 'agent_error': {
+          newState.errors = [...state.errors, event];
+          break;
+        }
+        case 'agent_output': {
+          newState.outputs = [...state.outputs, event];
+          break;
+        }
+        case 'progress_update': {
+          newState.progress = {
+            percentage: event.percentage,
+            currentPhase: event.currentPhase,
+            toolCallCount: event.toolCallCount,
+            elapsedSeconds: event.elapsedSeconds,
+            estimatedRemainingSeconds: event.estimatedRemainingSeconds,
+          };
+          break;
+        }
+      }
+
+      return newState;
+    }
+    case 'SET_PROGRESS':
+      return { ...state, progress: action.progress };
+    case 'CLEAR':
+      return {
+        events: [],
+        toolCalls: new Map(),
+        files: new Map(),
+        errors: [],
+        outputs: [],
+        progress: null,
+      };
+    default:
+      return state;
+  }
+}
+
+const initialState: StreamState = {
+  events: [],
+  toolCalls: new Map(),
+  files: new Map(),
+  errors: [],
+  outputs: [],
+  progress: null,
+};
+
+/**
+ * Hook to subscribe to run streaming events for a work order
+ */
+export function useRunStream(options: UseRunStreamOptions = {}): UseRunStreamResult {
+  const { maxEvents = 500, filters, autoConnect = true } = options;
+
+  const [state, dispatch] = useReducer(streamReducer, initialState);
+  const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
+  const [subscribedWorkOrderId, setSubscribedWorkOrderId] = useState<string | null>(null);
+
+  const wsClient = getWebSocketClient();
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
+
+  // Handle incoming WebSocket messages
+  const handleMessage = useCallback(
+    (message: WebSocketMessage) => {
+      // Check if message is for our subscribed work order
+      if ('workOrderId' in message && message.workOrderId !== subscribedWorkOrderId) {
+        return;
+      }
+
+      // Handle subscription confirmations
+      if (message.type === 'subscription_confirmed') {
+        return;
+      }
+
+      if (message.type === 'unsubscription_confirmed') {
+        setSubscribedWorkOrderId(null);
+        return;
+      }
+
+      // Handle run lifecycle events
+      if (message.type === 'run_started') {
+        const event: AgentEvent = {
+          type: 'run_started',
+          workOrderId: message.workOrderId,
+          runId: message.runId,
+          runNumber: message.runNumber,
+          timestamp: message.timestamp,
+        };
+        dispatch({ type: 'ADD_EVENT', event, maxEvents });
+        return;
+      }
+
+      if (message.type === 'run_completed') {
+        const event: AgentEvent = {
+          type: 'run_completed',
+          workOrderId: message.workOrderId,
+          runId: message.runId,
+          prUrl: message.prUrl,
+          branchName: message.branchName,
+          timestamp: message.timestamp,
+        };
+        dispatch({ type: 'ADD_EVENT', event, maxEvents });
+        return;
+      }
+
+      if (message.type === 'run_failed') {
+        const event: AgentEvent = {
+          type: 'run_failed',
+          workOrderId: message.workOrderId,
+          runId: message.runId,
+          error: message.error,
+          iterationNumber: message.iterationNumber,
+          timestamp: message.timestamp,
+        };
+        dispatch({ type: 'ADD_EVENT', event, maxEvents });
+        return;
+      }
+
+      // Handle agent events
+      if (
+        message.type === 'agent_tool_call' ||
+        message.type === 'agent_tool_result' ||
+        message.type === 'agent_output' ||
+        message.type === 'file_changed' ||
+        message.type === 'progress_update'
+      ) {
+        dispatch({ type: 'ADD_EVENT', event: message, maxEvents });
+        return;
+      }
+
+      // Handle errors
+      if (message.type === 'error') {
+        const errorEvent: AgentErrorEvent = {
+          type: 'agent_error',
+          workOrderId: subscribedWorkOrderId || 'unknown',
+          runId: 'unknown',
+          message: message.message,
+          details: message.details,
+          timestamp: message.timestamp,
+        };
+        dispatch({ type: 'ADD_EVENT', event: errorEvent, maxEvents });
+      }
+    },
+    [subscribedWorkOrderId, maxEvents]
+  );
+
+  // Subscribe to a work order
+  const subscribe = useCallback(
+    (workOrderId: string) => {
+      if (!wsClient.isConnected()) {
+        wsClient.connect();
+      }
+
+      const subscribeMessage = {
+        type: 'subscribe' as const,
+        workOrderId,
+        filters: filtersRef.current,
+      };
+
+      if (wsClient.send(subscribeMessage)) {
+        setSubscribedWorkOrderId(workOrderId);
+      }
+    },
+    [wsClient]
+  );
+
+  // Unsubscribe from current work order
+  const unsubscribe = useCallback(() => {
+    if (subscribedWorkOrderId) {
+      wsClient.send({
+        type: 'unsubscribe',
+        workOrderId: subscribedWorkOrderId,
+      });
+      setSubscribedWorkOrderId(null);
+    }
+  }, [wsClient, subscribedWorkOrderId]);
+
+  // Clear all events
+  const clearEvents = useCallback(() => {
+    dispatch({ type: 'CLEAR' });
+  }, []);
+
+  // Set up WebSocket connection and message handling
+  useEffect(() => {
+    // Subscribe to connection state changes
+    const originalOnChange = (wsClient as unknown as { onConnectionStateChange?: (state: ConnectionState) => void })['onConnectionStateChange'];
+    (wsClient as unknown as { onConnectionStateChange?: (state: ConnectionState) => void })['onConnectionStateChange'] = (state: ConnectionState) => {
+      setConnectionState(state);
+      originalOnChange?.(state);
+    };
+
+    // Subscribe to messages
+    const unsubscribeFromMessages = wsClient.subscribe(handleMessage);
+
+    // Auto-connect if enabled
+    if (autoConnect) {
+      wsClient.connect();
+    } else {
+      setConnectionState(wsClient.getConnectionState());
+    }
+
+    // Cleanup
+    return () => {
+      unsubscribeFromMessages();
+      if (subscribedWorkOrderId) {
+        wsClient.send({
+          type: 'unsubscribe',
+          workOrderId: subscribedWorkOrderId,
+        });
+      }
+    };
+  }, [wsClient, handleMessage, autoConnect, subscribedWorkOrderId]);
+
+  return {
+    events: state.events,
+    toolCalls: Array.from(state.toolCalls.values()),
+    files: Array.from(state.files.values()),
+    errors: state.errors,
+    outputs: state.outputs,
+    progress: state.progress,
+    isSubscribed: subscribedWorkOrderId !== null,
+    isConnected: connectionState === 'connected',
+    connectionState,
+    subscribe,
+    unsubscribe,
+    clearEvents,
+  };
+}

--- a/packages/dashboard/src/pages/WorkOrderDetail.tsx
+++ b/packages/dashboard/src/pages/WorkOrderDetail.tsx
@@ -5,6 +5,7 @@ import {
   WorkOrderInfo,
   WorkOrderTimeline,
 } from '../components/work-orders';
+import { AgentActivityPanel } from '../components/streaming';
 import { useWorkOrder, useRuns, useCancelWorkOrder } from '../hooks';
 import { LoadingSpinner, ErrorDisplay } from '../components/common';
 
@@ -73,6 +74,7 @@ export function WorkOrderDetail() {
   }
 
   const runs = runsData?.runs || [];
+  const isRunning = workOrder.status === 'running';
 
   return (
     <div className="space-y-6">
@@ -87,6 +89,16 @@ export function WorkOrderDetail() {
       <WorkOrderHeader workOrder={workOrder} onCancel={handleCancel} />
 
       <WorkOrderInfo workOrder={workOrder} />
+
+      {/* Live Activity Panel - shown when work order is running */}
+      {isRunning && id && (
+        <AgentActivityPanel
+          workOrderId={id}
+          maxEvents={500}
+          autoScroll={true}
+          className="relative"
+        />
+      )}
 
       <WorkOrderTimeline runs={runs} />
     </div>

--- a/packages/dashboard/src/types/agent-events.ts
+++ b/packages/dashboard/src/types/agent-events.ts
@@ -1,0 +1,208 @@
+/**
+ * Agent event types for streaming display
+ */
+
+/**
+ * Tool names that can be invoked by the agent
+ */
+export type AgentToolName =
+  | 'Read'
+  | 'Write'
+  | 'Edit'
+  | 'Bash'
+  | 'Grep'
+  | 'Glob'
+  | 'WebFetch'
+  | 'WebSearch'
+  | 'Other';
+
+/**
+ * Base event interface with common fields
+ */
+export interface BaseAgentEvent {
+  timestamp: string;
+  workOrderId: string;
+  runId: string;
+}
+
+/**
+ * Tool call event - when agent invokes a tool
+ */
+export interface AgentToolCallEvent extends BaseAgentEvent {
+  type: 'agent_tool_call';
+  toolUseId: string;
+  tool: AgentToolName;
+  input: Record<string, unknown>;
+}
+
+/**
+ * Tool result event - when tool execution completes
+ */
+export interface AgentToolResultEvent extends BaseAgentEvent {
+  type: 'agent_tool_result';
+  toolUseId: string;
+  success: boolean;
+  contentPreview: string;
+  contentLength: number;
+  durationMs: number;
+}
+
+/**
+ * Agent output event - text output from the agent
+ */
+export interface AgentOutputEvent extends BaseAgentEvent {
+  type: 'agent_output';
+  content: string;
+}
+
+/**
+ * File change action types
+ */
+export type FileChangeAction = 'created' | 'modified' | 'deleted';
+
+/**
+ * File changed event
+ */
+export interface FileChangedEvent extends BaseAgentEvent {
+  type: 'file_changed';
+  path: string;
+  action: FileChangeAction;
+  sizeBytes?: number;
+}
+
+/**
+ * Progress update event
+ */
+export interface ProgressUpdateEvent extends BaseAgentEvent {
+  type: 'progress_update';
+  percentage: number;
+  currentPhase: string;
+  toolCallCount: number;
+  elapsedSeconds: number;
+  estimatedRemainingSeconds?: number;
+}
+
+/**
+ * Error event
+ */
+export interface AgentErrorEvent extends BaseAgentEvent {
+  type: 'agent_error';
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Run started event
+ */
+export interface RunStartedEvent extends BaseAgentEvent {
+  type: 'run_started';
+  runNumber: number;
+}
+
+/**
+ * Run completed event
+ */
+export interface RunCompletedEvent extends BaseAgentEvent {
+  type: 'run_completed';
+  prUrl?: string;
+  branchName?: string;
+}
+
+/**
+ * Run failed event
+ */
+export interface RunFailedEvent extends BaseAgentEvent {
+  type: 'run_failed';
+  error: string;
+  iterationNumber?: number;
+}
+
+/**
+ * Union of all agent events
+ */
+export type AgentEvent =
+  | AgentToolCallEvent
+  | AgentToolResultEvent
+  | AgentOutputEvent
+  | FileChangedEvent
+  | ProgressUpdateEvent
+  | AgentErrorEvent
+  | RunStartedEvent
+  | RunCompletedEvent
+  | RunFailedEvent;
+
+/**
+ * Event type discriminator
+ */
+export type AgentEventType = AgentEvent['type'];
+
+/**
+ * Tool call with its result paired together
+ */
+export interface ToolCallWithResult {
+  call: AgentToolCallEvent;
+  result?: AgentToolResultEvent;
+}
+
+/**
+ * File change entry for file tracking
+ */
+export interface FileChange {
+  path: string;
+  action: FileChangeAction;
+  sizeBytes?: number;
+  timestamp: string;
+}
+
+/**
+ * Progress state for tracking execution
+ */
+export interface ProgressState {
+  percentage: number;
+  currentPhase: string;
+  toolCallCount: number;
+  elapsedSeconds: number;
+  estimatedRemainingSeconds?: number;
+}
+
+/**
+ * Event store state for managing streaming events
+ */
+export interface EventStoreState {
+  events: AgentEvent[];
+  toolCalls: Map<string, ToolCallWithResult>;
+  files: Map<string, FileChange>;
+  errors: AgentErrorEvent[];
+  progress: ProgressState | null;
+  outputs: AgentOutputEvent[];
+}
+
+/**
+ * Event store actions
+ */
+export type EventStoreAction =
+  | { type: 'ADD_EVENT'; event: AgentEvent }
+  | { type: 'SET_PROGRESS'; progress: ProgressState }
+  | { type: 'CLEAR' };
+
+/**
+ * Subscription filters for granular event filtering
+ */
+export interface SubscriptionFilters {
+  includeToolCalls?: boolean;
+  includeToolResults?: boolean;
+  includeOutput?: boolean;
+  includeFileChanges?: boolean;
+  includeProgress?: boolean;
+}
+
+/**
+ * Default subscription filters
+ */
+export const DEFAULT_SUBSCRIPTION_FILTERS: Required<SubscriptionFilters> = {
+  includeToolCalls: true,
+  includeToolResults: true,
+  includeOutput: true,
+  includeFileChanges: true,
+  includeProgress: true,
+};

--- a/packages/dashboard/src/types/index.ts
+++ b/packages/dashboard/src/types/index.ts
@@ -21,3 +21,6 @@ export type ApiResponse<T = unknown> = {
   data?: T
   error?: string
 }
+
+// Re-export agent event types
+export * from './agent-events'


### PR DESCRIPTION
## Summary
- **Thrust 5: Live Activity Panel** - Real-time display of agent tool calls and events as they stream in
- **Thrust 6: Run Detail Streaming** - Comprehensive run detail view with tabbed interface for activity, tools, output, files, and errors
- Extends WebSocket client with subscription management and new agent event types

## Changes

### New Components
| Component | Description |
|-----------|-------------|
| `AgentActivityPanel` | Real-time scrolling feed of agent events with connection status |
| `EventCard` | Individual event display with expand/collapse and copy functionality |
| `RunStreamView` | Tabbed container with progress header |
| `ProgressHeader` | Progress bar with tool call count, elapsed time, and ETA |
| `ToolCallsTab` | Tree view of tool calls with input/output and filtering |
| `OutputTab` | Agent text output with search and copy all |
| `FilesTab` | File changes grouped by directory |
| `ErrorsTab` | Error and warning list with details |

### New Hooks
- `useRunStream` - WebSocket subscription for work order streaming events

### New Types
- Agent event types: `AgentToolCallEvent`, `AgentToolResultEvent`, `AgentOutputEvent`, `FileChangedEvent`, `ProgressUpdateEvent`
- Event store state management types

### WebSocket Updates
- Added `send()` method to WebSocket client
- Extended `WebSocketMessage` union with new agent event types
- Added subscription message types

## Test plan
- [x] Dashboard typecheck passes: `pnpm typecheck`
- [x] Dashboard lint passes: `pnpm lint`
- [x] All 65 tests pass: `pnpm test`
- [ ] Manual: Open work order detail while running
- [ ] Manual: Verify live activity panel shows events
- [ ] Manual: Verify auto-scroll and pause behavior
- [ ] Manual: Verify all tabs show correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)