### PR TITLE
feat: implement audit trail and tests (v0.2.16 Thrusts 11-12)

### DIFF
--- a/packages/server/src/artifacts/paths.ts
+++ b/packages/server/src/artifacts/paths.ts
@@ -145,6 +145,15 @@ export function getTreePath(rootId: string): string {
   return join(getTreesDir(), `${rootId}.json`);
 }
 
+// Audit paths (v0.2.16 - Thrust 11)
+export function getAuditDir(): string {
+  return join(getAgentGateRoot(), 'audit');
+}
+
+export function getAuditPath(runId: string): string {
+  return join(getAuditDir(), `${runId}.json`);
+}
+
 // Ensure directories exist
 export async function ensureDir(path: string): Promise<void> {
   await mkdir(path, { recursive: true });
@@ -171,5 +180,6 @@ export async function ensureAllDirs(): Promise<void> {
     ensureDir(getSnapshotsDir()),
     ensureDir(getTmpDir()),
     ensureDir(getTreesDir()),
+    ensureDir(getAuditDir()),
   ]);
 }

--- a/packages/server/src/harness/audit-trail.ts
+++ b/packages/server/src/harness/audit-trail.ts
@@ -1,0 +1,450 @@
+/**
+ * Audit Trail Module
+ *
+ * Tracks harness configuration changes across iterations and runs.
+ * Provides a complete audit history of what configuration was active
+ * at each point in execution.
+ *
+ * @module harness/audit-trail
+ * @since v0.2.16 - Thrust 11
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { getAuditDir } from '../artifacts/paths.js';
+import { createLogger } from '../utils/logger.js';
+import type { ResolvedHarnessConfig } from '../types/harness-config.js';
+import { computeConfigHash } from './config-resolver.js';
+
+const logger = createLogger('audit-trail');
+
+/**
+ * Represents a change between two configurations.
+ */
+export interface ConfigChange {
+  /** Path to the changed field (e.g., "loopStrategy.maxIterations") */
+  path: string;
+  /** Previous value */
+  previousValue: unknown;
+  /** New value */
+  newValue: unknown;
+}
+
+/**
+ * A snapshot of configuration at a specific iteration.
+ */
+export interface ConfigSnapshot {
+  /** Unique snapshot ID */
+  id: string;
+  /** Associated work order ID */
+  workOrderId: string;
+  /** Run ID */
+  runId: string;
+  /** Iteration number (0 for initial) */
+  iteration: number;
+  /** Timestamp */
+  timestamp: Date;
+  /** The resolved configuration at this point */
+  config: ResolvedHarnessConfig;
+  /** Hash of the configuration for comparison */
+  configHash: string;
+  /** Changes from previous snapshot (null for initial) */
+  changesFromPrevious: ConfigChange[] | null;
+}
+
+/**
+ * Complete audit record for a run.
+ */
+export interface ConfigAuditRecord {
+  /** Run ID */
+  runId: string;
+  /** Work order ID */
+  workOrderId: string;
+  /** When the audit record was created */
+  createdAt: Date;
+  /** When the audit record was last updated */
+  updatedAt: Date;
+  /** Initial configuration snapshot */
+  initialConfig: ConfigSnapshot;
+  /** Snapshots for each iteration (if config changed) */
+  iterationSnapshots: ConfigSnapshot[];
+  /** Final configuration (same as last snapshot if no changes) */
+  finalConfig: ConfigSnapshot | null;
+  /** Total number of iterations */
+  totalIterations: number;
+  /** Whether configuration changed during execution */
+  configChanged: boolean;
+}
+
+/**
+ * Compares two configuration objects and returns the differences.
+ */
+function compareConfigs(
+  previous: ResolvedHarnessConfig,
+  current: ResolvedHarnessConfig,
+  basePath = ''
+): ConfigChange[] {
+  const changes: ConfigChange[] = [];
+
+  function compare(
+    prev: Record<string, unknown>,
+    curr: Record<string, unknown>,
+    path: string
+  ): void {
+    const allKeys = new Set([...Object.keys(prev), ...Object.keys(curr)]);
+
+    for (const key of allKeys) {
+      const fullPath = path ? `${path}.${key}` : key;
+      const prevValue = prev[key];
+      const currValue = curr[key];
+
+      if (prevValue === currValue) {
+        continue;
+      }
+
+      // Handle nested objects
+      if (
+        typeof prevValue === 'object' &&
+        typeof currValue === 'object' &&
+        prevValue !== null &&
+        currValue !== null &&
+        !Array.isArray(prevValue) &&
+        !Array.isArray(currValue)
+      ) {
+        compare(
+          prevValue as Record<string, unknown>,
+          currValue as Record<string, unknown>,
+          fullPath
+        );
+        continue;
+      }
+
+      // Handle arrays - compare as JSON strings
+      if (Array.isArray(prevValue) || Array.isArray(currValue)) {
+        if (JSON.stringify(prevValue) !== JSON.stringify(currValue)) {
+          changes.push({
+            path: fullPath,
+            previousValue: prevValue,
+            newValue: currValue,
+          });
+        }
+        continue;
+      }
+
+      // Primitive values changed
+      changes.push({
+        path: fullPath,
+        previousValue: prevValue,
+        newValue: currValue,
+      });
+    }
+  }
+
+  compare(
+    previous as unknown as Record<string, unknown>,
+    current as unknown as Record<string, unknown>,
+    basePath
+  );
+
+  return changes;
+}
+
+/**
+ * Audit Trail manager for tracking configuration changes.
+ */
+export class AuditTrail {
+  private record: ConfigAuditRecord | null = null;
+  private lastSnapshot: ConfigSnapshot | null = null;
+  private snapshotCounter = 0;
+
+  constructor(
+    private readonly workOrderId: string,
+    private readonly runId: string
+  ) {}
+
+  /**
+   * Record the initial configuration for a run.
+   */
+  recordInitialConfig(config: ResolvedHarnessConfig): ConfigSnapshot {
+    const snapshot = this.createSnapshot(config, 0, null);
+
+    this.record = {
+      runId: this.runId,
+      workOrderId: this.workOrderId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      initialConfig: snapshot,
+      iterationSnapshots: [],
+      finalConfig: null,
+      totalIterations: 0,
+      configChanged: false,
+    };
+
+    this.lastSnapshot = snapshot;
+
+    logger.debug(
+      {
+        runId: this.runId,
+        configHash: snapshot.configHash,
+      },
+      'Recorded initial configuration'
+    );
+
+    return snapshot;
+  }
+
+  /**
+   * Record configuration for an iteration.
+   * Only creates a new snapshot if the config changed.
+   */
+  recordIterationConfig(
+    config: ResolvedHarnessConfig,
+    iteration: number
+  ): ConfigSnapshot | null {
+    if (!this.record || !this.lastSnapshot) {
+      throw new Error('Must call recordInitialConfig before recordIterationConfig');
+    }
+
+    const currentHash = computeConfigHash(config);
+
+    // Check if config changed
+    if (currentHash === this.lastSnapshot.configHash) {
+      // No change, just update iteration count
+      this.record.totalIterations = iteration;
+      this.record.updatedAt = new Date();
+      return null;
+    }
+
+    // Config changed - create new snapshot
+    const changes = compareConfigs(this.lastSnapshot.config, config);
+    const snapshot = this.createSnapshot(config, iteration, changes);
+
+    this.record.iterationSnapshots.push(snapshot);
+    this.record.configChanged = true;
+    this.record.totalIterations = iteration;
+    this.record.updatedAt = new Date();
+    this.lastSnapshot = snapshot;
+
+    logger.info(
+      {
+        runId: this.runId,
+        iteration,
+        changesCount: changes.length,
+        configHash: snapshot.configHash,
+      },
+      'Configuration changed during iteration'
+    );
+
+    return snapshot;
+  }
+
+  /**
+   * Record the final configuration.
+   */
+  recordFinalConfig(config: ResolvedHarnessConfig, totalIterations: number): ConfigSnapshot {
+    if (!this.record) {
+      throw new Error('Must call recordInitialConfig before recordFinalConfig');
+    }
+
+    const currentHash = computeConfigHash(config);
+
+    // Check if this is different from last snapshot
+    if (this.lastSnapshot && currentHash === this.lastSnapshot.configHash) {
+      // No change, use last snapshot as final
+      this.record.finalConfig = this.lastSnapshot;
+      this.record.totalIterations = totalIterations;
+      this.record.updatedAt = new Date();
+      return this.lastSnapshot;
+    }
+
+    // Create final snapshot
+    const changes = this.lastSnapshot
+      ? compareConfigs(this.lastSnapshot.config, config)
+      : null;
+    const snapshot = this.createSnapshot(config, totalIterations, changes);
+
+    this.record.finalConfig = snapshot;
+    this.record.totalIterations = totalIterations;
+    this.record.updatedAt = new Date();
+
+    if (changes && changes.length > 0) {
+      this.record.configChanged = true;
+    }
+
+    logger.info(
+      {
+        runId: this.runId,
+        totalIterations,
+        configChanged: this.record.configChanged,
+      },
+      'Recorded final configuration'
+    );
+
+    return snapshot;
+  }
+
+  /**
+   * Get the complete audit record.
+   */
+  getRecord(): ConfigAuditRecord | null {
+    return this.record;
+  }
+
+  /**
+   * Get the initial configuration hash.
+   */
+  getInitialHash(): string | null {
+    return this.record?.initialConfig.configHash ?? null;
+  }
+
+  /**
+   * Check if configuration changed during execution.
+   */
+  hasConfigChanged(): boolean {
+    return this.record?.configChanged ?? false;
+  }
+
+  /**
+   * Get the number of configuration changes.
+   */
+  getChangeCount(): number {
+    return this.record?.iterationSnapshots.length ?? 0;
+  }
+
+  /**
+   * Save the audit record to disk.
+   */
+  async save(): Promise<void> {
+    if (!this.record) {
+      logger.warn({ runId: this.runId }, 'No audit record to save');
+      return;
+    }
+
+    const auditDir = getAuditDir();
+    const filePath = path.join(auditDir, `${this.runId}.json`);
+
+    // Ensure audit directory exists
+    await fs.mkdir(auditDir, { recursive: true });
+
+    // Serialize with date conversion
+    const serialized = JSON.stringify(
+      this.record,
+      (_, value: unknown) => {
+        if (value instanceof Date) {
+          return value.toISOString();
+        }
+        return value;
+      },
+      2
+    );
+
+    await fs.writeFile(filePath, serialized);
+
+    logger.debug(
+      {
+        runId: this.runId,
+        path: filePath,
+      },
+      'Saved audit record'
+    );
+  }
+
+  /**
+   * Create a snapshot object.
+   */
+  private createSnapshot(
+    config: ResolvedHarnessConfig,
+    iteration: number,
+    changes: ConfigChange[] | null
+  ): ConfigSnapshot {
+    this.snapshotCounter++;
+    return {
+      id: `${this.runId}-snap-${this.snapshotCounter}`,
+      workOrderId: this.workOrderId,
+      runId: this.runId,
+      iteration,
+      timestamp: new Date(),
+      config,
+      configHash: computeConfigHash(config),
+      changesFromPrevious: changes,
+    };
+  }
+}
+
+/**
+ * Load an audit record from disk.
+ */
+export async function loadAuditRecord(runId: string): Promise<ConfigAuditRecord | null> {
+  const auditDir = getAuditDir();
+  const filePath = path.join(auditDir, `${runId}.json`);
+
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+
+    // Convert date strings back to Date objects
+    const convertDates = (obj: Record<string, unknown>): void => {
+      for (const key of Object.keys(obj)) {
+        const value = obj[key];
+        if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+          obj[key] = new Date(value);
+        } else if (typeof value === 'object' && value !== null) {
+          convertDates(value as Record<string, unknown>);
+        }
+      }
+    };
+
+    convertDates(parsed);
+    return parsed as unknown as ConfigAuditRecord;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * List all audit records.
+ */
+export async function listAuditRecords(): Promise<string[]> {
+  const auditDir = getAuditDir();
+
+  try {
+    const files = await fs.readdir(auditDir);
+    return files
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.replace('.json', ''));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+/**
+ * Delete an audit record.
+ */
+export async function deleteAuditRecord(runId: string): Promise<boolean> {
+  const auditDir = getAuditDir();
+  const filePath = path.join(auditDir, `${runId}.json`);
+
+  try {
+    await fs.unlink(filePath);
+    logger.debug({ runId, path: filePath }, 'Deleted audit record');
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Create an audit trail for a run.
+ */
+export function createAuditTrail(workOrderId: string, runId: string): AuditTrail {
+  return new AuditTrail(workOrderId, runId);
+}

--- a/packages/server/src/harness/index.ts
+++ b/packages/server/src/harness/index.ts
@@ -69,3 +69,15 @@ export {
   type ResolveOptions,
   type CLIOptions,
 } from './config-resolver.js';
+
+// Audit Trail (v0.2.16 - Thrust 11)
+export {
+  AuditTrail,
+  createAuditTrail,
+  loadAuditRecord,
+  listAuditRecords,
+  deleteAuditRecord,
+  type ConfigChange,
+  type ConfigSnapshot,
+  type ConfigAuditRecord,
+} from './audit-trail.js';

--- a/packages/server/test/harness/audit-trail.test.ts
+++ b/packages/server/test/harness/audit-trail.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Audit Trail Tests
+ *
+ * @since v0.2.16 - Thrust 12
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  AuditTrail,
+  createAuditTrail,
+  loadAuditRecord,
+  listAuditRecords,
+  deleteAuditRecord,
+  type ConfigAuditRecord,
+} from '../../src/harness/audit-trail.js';
+import { setAgentGateRoot, getAuditDir } from '../../src/artifacts/paths.js';
+import type { ResolvedHarnessConfig } from '../../src/types/harness-config.js';
+import { LoopStrategyMode, GitOperationMode } from '../../src/types/harness-config.js';
+
+// Test fixtures
+function createTestConfig(overrides: Partial<ResolvedHarnessConfig> = {}): ResolvedHarnessConfig {
+  return {
+    version: '1.0',
+    loopStrategy: {
+      mode: LoopStrategyMode.FIXED,
+      maxIterations: 3,
+      completionDetection: ['verification_pass'],
+    },
+    agentDriver: {
+      type: 'claude-code-subscription',
+    },
+    verification: {
+      skipLevels: [],
+      timeoutMs: 300000,
+      cleanRoom: true,
+      parallelTests: true,
+      retryFlaky: false,
+      maxRetries: 0,
+    },
+    gitOps: {
+      mode: GitOperationMode.LOCAL,
+      branchPrefix: 'agentgate/',
+      commitMessagePrefix: '[AgentGate]',
+      autoCommit: true,
+      autoPush: false,
+      createPR: false,
+      prDraft: true,
+      prReviewers: [],
+      prLabels: [],
+    },
+    executionLimits: {
+      maxWallClockSeconds: 3600,
+      maxIterationSeconds: 600,
+      maxTotalTokens: 1000000,
+      maxIterationTokens: 100000,
+      maxDiskMb: 1024,
+      maxMemoryMb: 2048,
+      maxConcurrentAgents: 1,
+    },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('AuditTrail', () => {
+  let tempDir: string;
+  let originalRoot: string | undefined;
+
+  beforeEach(async () => {
+    // Create temp directory for tests
+    tempDir = await fs.mkdtemp(path.join(tmpdir(), 'agentgate-audit-test-'));
+    originalRoot = process.env['AGENTGATE_ROOT'];
+    setAgentGateRoot(tempDir);
+
+    // Ensure audit directory exists
+    await fs.mkdir(getAuditDir(), { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Restore original root
+    if (originalRoot) {
+      setAgentGateRoot(originalRoot);
+    }
+
+    // Cleanup temp directory
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('createAuditTrail', () => {
+    it('should create an audit trail instance', () => {
+      const trail = createAuditTrail('wo-123', 'run-456');
+      expect(trail).toBeInstanceOf(AuditTrail);
+    });
+  });
+
+  describe('AuditTrail instance', () => {
+    let trail: AuditTrail;
+
+    beforeEach(() => {
+      trail = createAuditTrail('wo-123', 'run-456');
+    });
+
+    it('should record initial configuration', () => {
+      const config = createTestConfig();
+      const snapshot = trail.recordInitialConfig(config);
+
+      expect(snapshot.id).toBeDefined();
+      expect(snapshot.workOrderId).toBe('wo-123');
+      expect(snapshot.runId).toBe('run-456');
+      expect(snapshot.iteration).toBe(0);
+      expect(snapshot.configHash).toBeDefined();
+      expect(snapshot.changesFromPrevious).toBeNull();
+    });
+
+    it('should not create new snapshot when config unchanged', () => {
+      const config = createTestConfig();
+      trail.recordInitialConfig(config);
+
+      const snapshot = trail.recordIterationConfig(config, 1);
+      expect(snapshot).toBeNull();
+    });
+
+    it('should create snapshot when config changes', () => {
+      const config1 = createTestConfig();
+      trail.recordInitialConfig(config1);
+
+      const config2 = createTestConfig({
+        loopStrategy: {
+          mode: LoopStrategyMode.HYBRID,
+          baseIterations: 5,
+          maxBonusIterations: 2,
+          progressThreshold: 0.1,
+          completionDetection: ['verification_pass'],
+          progressTracking: 'git_history',
+        },
+      });
+
+      const snapshot = trail.recordIterationConfig(config2, 1);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.changesFromPrevious).toBeDefined();
+      expect(snapshot!.changesFromPrevious!.length).toBeGreaterThan(0);
+    });
+
+    it('should detect config changes', () => {
+      const config1 = createTestConfig();
+      trail.recordInitialConfig(config1);
+
+      expect(trail.hasConfigChanged()).toBe(false);
+
+      const config2 = createTestConfig({
+        executionLimits: {
+          maxWallClockSeconds: 7200,
+          maxIterationSeconds: 600,
+          maxTotalTokens: 1000000,
+          maxIterationTokens: 100000,
+          maxDiskMb: 1024,
+          maxMemoryMb: 2048,
+          maxConcurrentAgents: 1,
+        },
+      });
+
+      trail.recordIterationConfig(config2, 1);
+      expect(trail.hasConfigChanged()).toBe(true);
+    });
+
+    it('should record final configuration', () => {
+      const config = createTestConfig();
+      trail.recordInitialConfig(config);
+      const finalSnapshot = trail.recordFinalConfig(config, 3);
+
+      // If config hasn't changed, finalSnapshot is the initial snapshot (iteration 0)
+      // The iteration field represents when this config was introduced
+      expect(finalSnapshot.iteration).toBe(0);
+      const record = trail.getRecord();
+      expect(record!.finalConfig).not.toBeNull();
+      expect(record!.totalIterations).toBe(3);
+    });
+
+    it('should save and load audit record', async () => {
+      const config = createTestConfig();
+      trail.recordInitialConfig(config);
+      trail.recordFinalConfig(config, 2);
+
+      await trail.save();
+
+      const loaded = await loadAuditRecord('run-456');
+      expect(loaded).not.toBeNull();
+      expect(loaded!.runId).toBe('run-456');
+      expect(loaded!.workOrderId).toBe('wo-123');
+    });
+  });
+
+  describe('loadAuditRecord', () => {
+    it('should return null for non-existent record', async () => {
+      const loaded = await loadAuditRecord('non-existent');
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('listAuditRecords', () => {
+    it('should list all audit records', async () => {
+      // Create multiple trails
+      const trail1 = createAuditTrail('wo-1', 'run-1');
+      trail1.recordInitialConfig(createTestConfig());
+      await trail1.save();
+
+      const trail2 = createAuditTrail('wo-2', 'run-2');
+      trail2.recordInitialConfig(createTestConfig());
+      await trail2.save();
+
+      const records = await listAuditRecords();
+      expect(records).toContain('run-1');
+      expect(records).toContain('run-2');
+    });
+
+    it('should return empty array when no records exist', async () => {
+      const records = await listAuditRecords();
+      expect(records).toEqual([]);
+    });
+  });
+
+  describe('deleteAuditRecord', () => {
+    it('should delete existing record', async () => {
+      const trail = createAuditTrail('wo-123', 'run-to-delete');
+      trail.recordInitialConfig(createTestConfig());
+      await trail.save();
+
+      const deleted = await deleteAuditRecord('run-to-delete');
+      expect(deleted).toBe(true);
+
+      const loaded = await loadAuditRecord('run-to-delete');
+      expect(loaded).toBeNull();
+    });
+
+    it('should return false for non-existent record', async () => {
+      const deleted = await deleteAuditRecord('non-existent');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('Config comparison', () => {
+    it('should detect nested object changes', () => {
+      const trail = createAuditTrail('wo-123', 'run-456');
+
+      const config1 = createTestConfig();
+      trail.recordInitialConfig(config1);
+
+      const config2 = createTestConfig({
+        verification: {
+          skipLevels: ['L0'],
+          timeoutMs: 600000,
+          cleanRoom: false,
+          parallelTests: true,
+          retryFlaky: true,
+          maxRetries: 3,
+        },
+      });
+
+      const snapshot = trail.recordIterationConfig(config2, 1);
+      expect(snapshot).not.toBeNull();
+
+      const changes = snapshot!.changesFromPrevious!;
+      const paths = changes.map(c => c.path);
+
+      expect(paths).toContain('verification.skipLevels');
+      expect(paths).toContain('verification.timeoutMs');
+      expect(paths).toContain('verification.cleanRoom');
+    });
+
+    it('should handle array changes', () => {
+      const trail = createAuditTrail('wo-123', 'run-456');
+
+      const config1 = createTestConfig({
+        loopStrategy: {
+          mode: LoopStrategyMode.FIXED,
+          maxIterations: 3,
+          completionDetection: ['verification_pass'],
+        },
+      });
+      trail.recordInitialConfig(config1);
+
+      const config2 = createTestConfig({
+        loopStrategy: {
+          mode: LoopStrategyMode.FIXED,
+          maxIterations: 3,
+          completionDetection: ['verification_pass', 'no_changes', 'ci_pass'],
+        },
+      });
+
+      const snapshot = trail.recordIterationConfig(config2, 1);
+      expect(snapshot).not.toBeNull();
+
+      const changes = snapshot!.changesFromPrevious!;
+      const completionChange = changes.find(c => c.path === 'loopStrategy.completionDetection');
+      expect(completionChange).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements audit trail system for tracking harness configuration changes
- Adds comprehensive test coverage for audit functionality
- Part of v0.2.16 Work Order Harness Configuration System

## Changes
- `audit-trail.ts`: AuditTrail class, ConfigSnapshot, ConfigAuditRecord types
- `paths.ts`: Added getAuditDir() helper  
- `harness/index.ts`: Export audit trail functions
- `audit-trail.test.ts`: 14 tests covering all audit trail functionality

## Test plan
- [x] All 14 audit trail tests pass
- [x] Lint passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)