### PR TITLE
feat(queue): implement RetryManager (v0.2.22 Thrust 5)

### DIFF
--- a/packages/server/src/queue/retry-manager.ts
+++ b/packages/server/src/queue/retry-manager.ts
@@ -1,0 +1,249 @@
+import { EventEmitter } from 'events';
+import type { Logger } from 'pino';
+import { createLogger } from '../utils/logger.js';
+import type { RetryPolicy, RetryState } from './types.js';
+import { DEFAULT_RETRY_POLICY } from './types.js';
+import type { WorkOrderStateMachine } from './state-machine.js';
+
+/**
+ * Events emitted by RetryManager.
+ */
+export interface RetryManagerEvents {
+  'retry-scheduled': (workOrderId: string, delay: number, attemptNumber: number) => void;
+  'retry-triggered': (workOrderId: string, attemptNumber: number) => void;
+  'retry-exhausted': (workOrderId: string, attempts: number) => void;
+  'retry-cancelled': (workOrderId: string) => void;
+}
+
+/**
+ * Callback when a retry should be executed.
+ */
+export type RetryCallback = (workOrderId: string) => void;
+
+/**
+ * Manages retry logic with exponential backoff.
+ */
+export class RetryManager extends EventEmitter {
+  private readonly logger: Logger;
+  private readonly policy: RetryPolicy;
+  private readonly retryStates: Map<string, RetryState> = new Map();
+  private retryCallback: RetryCallback | null = null;
+
+  constructor(policy: Partial<RetryPolicy> = {}) {
+    super();
+    this.policy = { ...DEFAULT_RETRY_POLICY, ...policy };
+    this.logger = createLogger('retry-manager');
+
+    this.logger.info(
+      { policy: this.policy },
+      'RetryManager initialized'
+    );
+  }
+
+  /**
+   * Set the callback to invoke when a retry should happen.
+   */
+  setRetryCallback(callback: RetryCallback): void {
+    this.retryCallback = callback;
+  }
+
+  /**
+   * Check if a work order should be retried.
+   */
+  shouldRetry(workOrderId: string, stateMachine: WorkOrderStateMachine, retryable: boolean): boolean {
+    if (!retryable) {
+      this.logger.debug(
+        { workOrderId },
+        'Error is not retryable'
+      );
+      return false;
+    }
+
+    const attempts = stateMachine.retryCount;
+    if (attempts >= this.policy.maxRetries) {
+      this.logger.info(
+        { workOrderId, attempts, maxRetries: this.policy.maxRetries },
+        'Max retries exceeded'
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Calculate delay for next retry using exponential backoff with jitter.
+   */
+  calculateDelay(attemptNumber: number): number {
+    // Exponential backoff: baseDelay * (multiplier ^ attempt)
+    const exponentialDelay = this.policy.baseDelayMs *
+      Math.pow(this.policy.backoffMultiplier, attemptNumber);
+
+    // Cap at max delay
+    const cappedDelay = Math.min(exponentialDelay, this.policy.maxDelayMs);
+
+    // Add jitter
+    const jitter = cappedDelay * this.policy.jitterFactor * Math.random();
+    const finalDelay = Math.floor(cappedDelay + jitter);
+
+    this.logger.debug(
+      { attemptNumber, baseDelay: this.policy.baseDelayMs, exponentialDelay, cappedDelay, jitter, finalDelay },
+      'Calculated retry delay'
+    );
+
+    return finalDelay;
+  }
+
+  /**
+   * Schedule a retry for a work order.
+   */
+  scheduleRetry(
+    workOrderId: string,
+    stateMachine: WorkOrderStateMachine,
+    errorMessage: string
+  ): void {
+    const attemptNumber = stateMachine.retryCount;
+    const delay = this.calculateDelay(attemptNumber);
+    const nextRetryAt = new Date(Date.now() + delay);
+
+    // Cancel any existing scheduled retry
+    this.cancelRetry(workOrderId);
+
+    // Schedule the retry
+    const timerId = setTimeout(() => {
+      this.executeRetry(workOrderId, stateMachine);
+    }, delay);
+
+    // Store retry state
+    const state: RetryState = {
+      workOrderId,
+      attemptNumber: attemptNumber + 1,
+      nextRetryAt,
+      lastError: errorMessage,
+      scheduledTimerId: timerId,
+    };
+
+    this.retryStates.set(workOrderId, state);
+
+    this.logger.info(
+      { workOrderId, attemptNumber: state.attemptNumber, delay, nextRetryAt },
+      'Retry scheduled'
+    );
+
+    this.emit('retry-scheduled', workOrderId, delay, state.attemptNumber);
+  }
+
+  /**
+   * Execute a scheduled retry.
+   */
+  private executeRetry(workOrderId: string, stateMachine: WorkOrderStateMachine): void {
+    const state = this.retryStates.get(workOrderId);
+    if (!state) {
+      this.logger.warn(
+        { workOrderId },
+        'Retry state not found, may have been cancelled'
+      );
+      return;
+    }
+
+    this.logger.info(
+      { workOrderId, attemptNumber: state.attemptNumber },
+      'Executing retry'
+    );
+
+    // Clear scheduled state
+    state.scheduledTimerId = null;
+    this.retryStates.delete(workOrderId);
+
+    // Transition state machine
+    try {
+      stateMachine.retry();
+    } catch (err) {
+      this.logger.error(
+        { workOrderId, err },
+        'Failed to transition to retry state'
+      );
+      return;
+    }
+
+    // Emit event
+    this.emit('retry-triggered', workOrderId, state.attemptNumber);
+
+    // Invoke callback to re-enqueue
+    if (this.retryCallback) {
+      this.retryCallback(workOrderId);
+    } else {
+      this.logger.warn(
+        { workOrderId },
+        'No retry callback set'
+      );
+    }
+  }
+
+  /**
+   * Cancel a scheduled retry.
+   */
+  cancelRetry(workOrderId: string): boolean {
+    const state = this.retryStates.get(workOrderId);
+    if (!state) {
+      return false;
+    }
+
+    if (state.scheduledTimerId) {
+      clearTimeout(state.scheduledTimerId);
+    }
+
+    this.retryStates.delete(workOrderId);
+
+    this.logger.info(
+      { workOrderId },
+      'Retry cancelled'
+    );
+
+    this.emit('retry-cancelled', workOrderId);
+    return true;
+  }
+
+  /**
+   * Cancel all scheduled retries.
+   */
+  cancelAll(): void {
+    for (const [workOrderId, state] of this.retryStates) {
+      if (state.scheduledTimerId) {
+        clearTimeout(state.scheduledTimerId);
+      }
+      this.emit('retry-cancelled', workOrderId);
+    }
+
+    this.retryStates.clear();
+
+    this.logger.info('All retries cancelled');
+  }
+
+  /**
+   * Get retry state for a work order.
+   */
+  getRetryState(workOrderId: string): RetryState | undefined {
+    return this.retryStates.get(workOrderId);
+  }
+
+  /**
+   * Get all pending retries.
+   */
+  getPendingRetries(): RetryState[] {
+    return Array.from(this.retryStates.values());
+  }
+
+  /**
+   * Get retry statistics.
+   */
+  getStats(): {
+    pendingCount: number;
+    policy: RetryPolicy;
+  } {
+    return {
+      pendingCount: this.retryStates.size,
+      policy: this.policy,
+    };
+  }
+}

--- a/packages/server/src/queue/types.ts
+++ b/packages/server/src/queue/types.ts
@@ -65,3 +65,45 @@ export interface StateTransition {
   readonly timestamp: Date;
   readonly metadata?: Record<string, unknown>;
 }
+
+/**
+ * Retry policy configuration.
+ */
+export interface RetryPolicy {
+  /** Maximum number of retry attempts */
+  maxRetries: number;
+
+  /** Base delay in milliseconds before first retry */
+  baseDelayMs: number;
+
+  /** Maximum delay cap in milliseconds */
+  maxDelayMs: number;
+
+  /** Multiplier for exponential backoff (e.g., 2 = double each retry) */
+  backoffMultiplier: number;
+
+  /** Optional jitter factor (0-1) to add randomness */
+  jitterFactor: number;
+}
+
+/**
+ * Default retry policy.
+ */
+export const DEFAULT_RETRY_POLICY: RetryPolicy = {
+  maxRetries: 3,
+  baseDelayMs: 5000,      // 5 seconds
+  maxDelayMs: 300000,     // 5 minutes
+  backoffMultiplier: 2,
+  jitterFactor: 0.1,
+};
+
+/**
+ * Retry state for a work order.
+ */
+export interface RetryState {
+  workOrderId: string;
+  attemptNumber: number;
+  nextRetryAt: Date | null;
+  lastError: string;
+  scheduledTimerId: NodeJS.Timeout | null;
+}

--- a/packages/server/test/unit/queue/retry-manager.test.ts
+++ b/packages/server/test/unit/queue/retry-manager.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RetryManager } from '../../../src/queue/retry-manager.js';
+import { WorkOrderStateMachine } from '../../../src/queue/state-machine.js';
+
+describe('RetryManager', () => {
+  let retryManager: RetryManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    retryManager = new RetryManager({
+      maxRetries: 3,
+      baseDelayMs: 1000,
+      maxDelayMs: 10000,
+      backoffMultiplier: 2,
+      jitterFactor: 0,  // No jitter for predictable tests
+    });
+  });
+
+  afterEach(() => {
+    retryManager.cancelAll();
+    vi.useRealTimers();
+  });
+
+  function createStateMachine(id: string): WorkOrderStateMachine {
+    const sm = new WorkOrderStateMachine({
+      workOrderId: id,
+      maxRetries: 3,
+    });
+    // Transition to a state where retry is valid
+    sm.claim();
+    sm.ready();
+    sm.fail({ message: 'Test error', retryable: true });
+    return sm;
+  }
+
+  describe('shouldRetry', () => {
+    it('should return true for retryable error within limit', () => {
+      const sm = new WorkOrderStateMachine({
+        workOrderId: 'test',
+        maxRetries: 3,
+      });
+      expect(retryManager.shouldRetry('test', sm, true)).toBe(true);
+    });
+
+    it('should return false for non-retryable error', () => {
+      const sm = new WorkOrderStateMachine({
+        workOrderId: 'test',
+        maxRetries: 3,
+      });
+      expect(retryManager.shouldRetry('test', sm, false)).toBe(false);
+    });
+
+    it('should return false when max retries exceeded', () => {
+      const sm = new WorkOrderStateMachine({
+        workOrderId: 'test',
+        maxRetries: 3,
+      });
+      // Simulate reaching max retries (3)
+      // First retry
+      sm.claim();
+      sm.ready();
+      sm.fail({ message: 'Error', retryable: true });
+      sm.retry();
+      // Second retry
+      sm.claim();
+      sm.ready();
+      sm.fail({ message: 'Error', retryable: true });
+      sm.retry();
+      // Third retry
+      sm.claim();
+      sm.ready();
+      sm.fail({ message: 'Error', retryable: true });
+      sm.retry();
+
+      // Now retryCount is 3, which equals maxRetries (3)
+      expect(retryManager.shouldRetry('test', sm, true)).toBe(false);
+    });
+  });
+
+  describe('calculateDelay', () => {
+    it('should calculate exponential backoff', () => {
+      expect(retryManager.calculateDelay(0)).toBe(1000);   // 1000 * 2^0 = 1000
+      expect(retryManager.calculateDelay(1)).toBe(2000);   // 1000 * 2^1 = 2000
+      expect(retryManager.calculateDelay(2)).toBe(4000);   // 1000 * 2^2 = 4000
+      expect(retryManager.calculateDelay(3)).toBe(8000);   // 1000 * 2^3 = 8000
+    });
+
+    it('should cap at max delay', () => {
+      expect(retryManager.calculateDelay(10)).toBe(10000); // Capped
+    });
+  });
+
+  describe('scheduleRetry', () => {
+    it('should schedule retry with correct delay', () => {
+      const sm = createStateMachine('test');
+      const scheduled = vi.fn();
+      retryManager.on('retry-scheduled', scheduled);
+
+      retryManager.scheduleRetry('test', sm, 'Test error');
+
+      expect(scheduled).toHaveBeenCalledWith('test', 1000, 1);
+      expect(retryManager.getRetryState('test')).toBeDefined();
+    });
+
+    it('should trigger retry callback after delay', () => {
+      const sm = createStateMachine('test');
+      const callback = vi.fn();
+      retryManager.setRetryCallback(callback);
+
+      retryManager.scheduleRetry('test', sm, 'Test error');
+
+      expect(callback).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(callback).toHaveBeenCalledWith('test');
+    });
+
+    it('should transition state machine on retry', () => {
+      const sm = createStateMachine('test');
+      retryManager.setRetryCallback(() => {});
+
+      retryManager.scheduleRetry('test', sm, 'Test error');
+      vi.advanceTimersByTime(1000);
+
+      expect(sm.currentState).toBe('PENDING');
+      expect(sm.retryCount).toBe(1);
+    });
+  });
+
+  describe('cancelRetry', () => {
+    it('should cancel scheduled retry', () => {
+      const sm = createStateMachine('test');
+      const callback = vi.fn();
+      retryManager.setRetryCallback(callback);
+
+      retryManager.scheduleRetry('test', sm, 'Test error');
+      retryManager.cancelRetry('test');
+
+      vi.advanceTimersByTime(1000);
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(retryManager.getRetryState('test')).toBeUndefined();
+    });
+
+    it('should emit cancelled event', () => {
+      const sm = createStateMachine('test');
+      const cancelled = vi.fn();
+      retryManager.on('retry-cancelled', cancelled);
+
+      retryManager.scheduleRetry('test', sm, 'Test error');
+      retryManager.cancelRetry('test');
+
+      expect(cancelled).toHaveBeenCalledWith('test');
+    });
+  });
+
+  describe('cancelAll', () => {
+    it('should cancel all scheduled retries', () => {
+      const sm1 = createStateMachine('test1');
+      const sm2 = createStateMachine('test2');
+      const callback = vi.fn();
+      retryManager.setRetryCallback(callback);
+
+      retryManager.scheduleRetry('test1', sm1, 'Error');
+      retryManager.scheduleRetry('test2', sm2, 'Error');
+      retryManager.cancelAll();
+
+      vi.advanceTimersByTime(10000);
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(retryManager.getPendingRetries()).toHaveLength(0);
+    });
+  });
+
+  describe('jitter', () => {
+    it('should add randomness when jitter factor is set', () => {
+      const jitterManager = new RetryManager({
+        baseDelayMs: 1000,
+        maxDelayMs: 10000,
+        backoffMultiplier: 2,
+        jitterFactor: 0.5,
+      });
+
+      // With jitter, delays should vary
+      const delays = new Set<number>();
+      for (let i = 0; i < 10; i++) {
+        delays.add(jitterManager.calculateDelay(0));
+      }
+
+      // With 50% jitter, delays should be between 1000 and 1500
+      for (const delay of delays) {
+        expect(delay).toBeGreaterThanOrEqual(1000);
+        expect(delay).toBeLessThanOrEqual(1500);
+      }
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return stats with pending count and policy', () => {
+      const sm = createStateMachine('test');
+      retryManager.scheduleRetry('test', sm, 'Error');
+
+      const stats = retryManager.getStats();
+
+      expect(stats.pendingCount).toBe(1);
+      expect(stats.policy.maxRetries).toBe(3);
+      expect(stats.policy.baseDelayMs).toBe(1000);
+    });
+  });
+
+  describe('getPendingRetries', () => {
+    it('should return all pending retry states', () => {
+      const sm1 = createStateMachine('test1');
+      const sm2 = createStateMachine('test2');
+
+      retryManager.scheduleRetry('test1', sm1, 'Error 1');
+      retryManager.scheduleRetry('test2', sm2, 'Error 2');
+
+      const pending = retryManager.getPendingRetries();
+
+      expect(pending).toHaveLength(2);
+      expect(pending.map(p => p.workOrderId).sort()).toEqual(['test1', 'test2']);
+    });
+  });
+
+  describe('event emission', () => {
+    it('should emit retry-triggered when retry executes', () => {
+      const sm = createStateMachine('test');
+      const triggered = vi.fn();
+      retryManager.on('retry-triggered', triggered);
+      retryManager.setRetryCallback(() => {});
+
+      retryManager.scheduleRetry('test', sm, 'Error');
+      vi.advanceTimersByTime(1000);
+
+      expect(triggered).toHaveBeenCalledWith('test', 1);
+    });
+
+    it('should emit retry-cancelled for each cancelled retry in cancelAll', () => {
+      const sm1 = createStateMachine('test1');
+      const sm2 = createStateMachine('test2');
+      const cancelled = vi.fn();
+      retryManager.on('retry-cancelled', cancelled);
+
+      retryManager.scheduleRetry('test1', sm1, 'Error');
+      retryManager.scheduleRetry('test2', sm2, 'Error');
+      retryManager.cancelAll();
+
+      expect(cancelled).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle scheduling same work order twice (cancels first)', () => {
+      const sm = createStateMachine('test');
+      const scheduled = vi.fn();
+      const cancelled = vi.fn();
+      retryManager.on('retry-scheduled', scheduled);
+      retryManager.on('retry-cancelled', cancelled);
+
+      retryManager.scheduleRetry('test', sm, 'Error 1');
+      retryManager.scheduleRetry('test', sm, 'Error 2');
+
+      expect(scheduled).toHaveBeenCalledTimes(2);
+      expect(cancelled).toHaveBeenCalledTimes(1);
+      expect(retryManager.getPendingRetries()).toHaveLength(1);
+      expect(retryManager.getRetryState('test')?.lastError).toBe('Error 2');
+    });
+
+    it('should handle cancelRetry for non-existent work order', () => {
+      const result = retryManager.cancelRetry('non-existent');
+      expect(result).toBe(false);
+    });
+
+    it('should handle retry without callback set', () => {
+      const sm = createStateMachine('test');
+
+      // No callback set - should not throw
+      retryManager.scheduleRetry('test', sm, 'Error');
+      vi.advanceTimersByTime(1000);
+
+      // State machine should still transition
+      expect(sm.currentState).toBe('PENDING');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement RetryManager with exponential backoff for handling transient failures
- Add RetryPolicy and RetryState types to types.ts with sensible defaults
- Integrate with WorkOrderStateMachine for automatic retry scheduling

## Changes
- `packages/server/src/queue/types.ts` - Added RetryPolicy, RetryState types and DEFAULT_RETRY_POLICY
- `packages/server/src/queue/retry-manager.ts` - New RetryManager implementation with:
  - Exponential backoff calculation with configurable jitter
  - Timer-based retry scheduling
  - Event emission for retry lifecycle (scheduled, triggered, cancelled)
  - Retry state tracking per work order
- `packages/server/test/unit/queue/retry-manager.test.ts` - 19 comprehensive unit tests

## Test plan
- [x] All 19 RetryManager unit tests pass
- [x] TypeScript typecheck passes
- [x] Exponential backoff calculation verified
- [x] Timer management and cancellation tested
- [x] State machine integration tested

## Dependencies
- Depends on Thrust 2 (State Machine) - already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)