### PR TITLE
fix(storage): use path.join for cross-platform path compatibility

### DIFF
--- a/packages/server/src/control-plane/work-order-store.ts
+++ b/packages/server/src/control-plane/work-order-store.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, readdir, unlink } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   getWorkOrdersDir,
   getWorkOrderPath,
@@ -256,7 +257,7 @@ export class WorkOrderStore {
 
     for (const file of jsonFiles) {
       try {
-        const content = await readFile(`${dir}/${file}`, 'utf-8');
+        const content = await readFile(join(dir, file), 'utf-8');
         const data = JSON.parse(content) as SerializedWorkOrder;
         const order = deserialize(data);
 
@@ -356,7 +357,7 @@ export class WorkOrderStore {
     let count = 0;
     for (const file of files.filter(f => f.endsWith('.json'))) {
       try {
-        const content = await readFile(`${dir}/${file}`, 'utf-8');
+        const content = await readFile(join(dir, file), 'utf-8');
         const data = JSON.parse(content) as SerializedWorkOrder;
         if (data.status === status) {
           count++;
@@ -441,7 +442,7 @@ export class WorkOrderStore {
     const corruptedFiles: string[] = [];
 
     for (const fileName of jsonFiles) {
-      const filePath = `${dir}/${fileName}`;
+      const filePath = join(dir, fileName);
       const result = await this.validateFile(fileName, filePath);
       results.push(result);
 
@@ -649,7 +650,7 @@ export class WorkOrderStore {
 
     for (const file of jsonFiles) {
       try {
-        const content = await readFile(`${dir}/${file}`, 'utf-8');
+        const content = await readFile(join(dir, file), 'utf-8');
         const data = JSON.parse(content) as SerializedWorkOrder;
         const order = deserialize(data);
 


### PR DESCRIPTION
## Summary

- Replace string concatenation with `path.join()` in work-order-store.ts to fix Windows path separator issues
- On Windows, mixing forward slashes from string concatenation with backslashes from path operations caused path comparison failures in tests

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Storage validation tests pass on Linux
- [ ] Verify tests pass on macOS CI
- [ ] Verify tests pass on Windows CI

Fixes 3 test failures in `test/storage-validation.test.ts` on Windows:
1. should detect invalid JSON files
2. should detect files with missing required fields  
3. should return paths of corrupted files

🤖 Generated with [Claude Code](https://claude.com/claude-code)